### PR TITLE
fix: firmware flashing robustness for Windows boards (closes #76)

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -69,3 +69,7 @@ config :trenino, :connection_initial_delay_ms, 0
 
 # Enable BLDC levers in tests so BLDC-related tests pass
 config :trenino, :enable_bldc_levers, true
+
+# Shorter call timeout in tests so port-timeout tests don't wait the full
+# production 5s. Production default stays 5000ms via Application.get_env.
+config :trenino, :serial_connection_call_timeout_ms, 500

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,11 +26,11 @@ config :trenino, TreninoWeb.Endpoint,
   secret_key_base: "NvZHOhdHQPBJ0Es1QVYQfVjXzJ9sSiQLWARJBAYZBR4yh+YZ3u0/M0d6grAy8QMQ",
   server: false
 
-# Suppress all logs during tests. ExUnit.start(capture_log: true) captures
-# per-test-process logs and shows them on failure; this setting silences
-# logs emitted from background GenServers (e.g. DeviceRegistry) which
-# don't have a test-process owner and would otherwise leak into output.
-config :logger, level: :none
+# Print only warnings and errors during test. ExUnit.start(capture_log: true)
+# captures per-test-process logs and shows them on failure; tests that
+# intentionally trigger noisy background-GenServer logs (e.g. DeviceRegistry
+# fallbacks) wrap their calls in ExUnit.CaptureLog.capture_log/1 explicitly.
+config :logger, level: :warning
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,8 +26,11 @@ config :trenino, TreninoWeb.Endpoint,
   secret_key_base: "NvZHOhdHQPBJ0Es1QVYQfVjXzJ9sSiQLWARJBAYZBR4yh+YZ3u0/M0d6grAy8QMQ",
   server: false
 
-# Print only warnings and errors during test
-config :logger, level: :warning
+# Suppress all logs during tests. ExUnit.start(capture_log: true) captures
+# per-test-process logs and shows them on failure; this setting silences
+# logs emitted from background GenServers (e.g. DeviceRegistry) which
+# don't have a test-process owner and would otherwise leak into output.
+config :logger, level: :none
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/docs/superpowers/plans/2026-05-03-test-suite-cleanup.md
+++ b/docs/superpowers/plans/2026-05-03-test-suite-cleanup.md
@@ -1,0 +1,930 @@
+# Test Suite Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the test suite fast (< 60s), flake-free, quiet, and incapable of touching real serial/avrdude hardware.
+
+**Architecture:** Add Mimic-based forbidden default stubs that raise on any unstubbed call to `Circuits.UART` / `Avrdude` / `AvrdudeRunner` / `Serial.Discovery`. Wire defaults in three case templates (`DataCase`, `ConnCase`, new `SerialSafetyCase`) using Mimic's `:private` mode so async tests stay safe. Replace `Process.sleep(N)` race patterns with deterministic synchronization (PubSub subscriber handshake, Task await, configurable timeouts). Demote one expected error log.
+
+**Tech Stack:** Elixir 1.19, Phoenix 1.8, Mimic 2.3 (already in deps), `Circuits.UART`, `Phoenix.PubSub`.
+
+---
+
+## File Structure
+
+**New files:**
+- `test/support/forbidden_serial.ex` — three stub modules (`Trenino.Test.ForbiddenUART`, `Trenino.Test.ForbiddenAvrdude`, `Trenino.Test.ForbiddenSerialDiscovery`) that raise on call.
+- `test/support/serial_safety_case.ex` — `Trenino.SerialSafetyCase` template for plain-`ExUnit.Case` files that need the safety net but no DB sandbox.
+- `test/support/pubsub_helpers.ex` — `Trenino.PubSubHelpers.wait_for_subscriber/2` deterministic wait helper.
+
+**Modified files:**
+- `test/support/data_case.ex` — wire forbidden stubs into setup; add `silently/1` capture helper.
+- `test/support/conn_case.ex` — wire forbidden stubs into setup.
+- `lib/trenino/firmware/device_registry.ex` — demote one `Logger.warning` → `Logger.info`.
+- `test/trenino/mcp/tools/detection_tools_test.exs` — replace `Process.sleep(50)` with `wait_for_subscriber/2`.
+- `test/trenino_web/live/configuration_list_live_test.exs` — fix 7 slow tests by stubbing the LiveView mount-time GenServer.call that's timing out at 5000ms (see Task 6).
+- `test/trenino/train/lever_controller_bldc_test.exs` — fix 4 slow tests by waiting on actual signal.
+- `test/trenino/integration/bldc_lever_flow_test.exs` — fix 3 slow tests by waiting on actual signal.
+- `test/trenino/serial/connection_port_timeout_test.exs` — drive timeout via app config to halve wall-clock cost.
+
+**Per-task additions:** any plain-`ExUnit.Case` test file that surfaces in Task 2 audit gets `use Trenino.SerialSafetyCase` (or `use Mimic` + per-test `expect/3`).
+
+---
+
+## Task 1: Add forbidden default stubs
+
+**Files:**
+- Create: `test/support/forbidden_serial.ex`
+
+- [ ] **Step 1: Create the stub modules**
+
+Write `test/support/forbidden_serial.ex`:
+
+```elixir
+defmodule Trenino.Test.ForbiddenUART do
+  @moduledoc """
+  Default Mimic stub for Circuits.UART. Every function raises with a clear
+  message so tests that forget to stub real serial access fail loudly instead
+  of touching real hardware.
+  """
+
+  def open(_pid, _port, _opts), do: forbid("Circuits.UART.open/3")
+  def close(_pid), do: forbid("Circuits.UART.close/1")
+  def write(_pid, _data), do: forbid("Circuits.UART.write/2")
+  def read(_pid, _timeout), do: forbid("Circuits.UART.read/2")
+  def enumerate, do: forbid("Circuits.UART.enumerate/0")
+  def start_link, do: forbid("Circuits.UART.start_link/0")
+  def start_link(_opts), do: forbid("Circuits.UART.start_link/1")
+  def controlling_process(_pid, _new_owner), do: forbid("Circuits.UART.controlling_process/2")
+  def configure(_pid, _opts), do: forbid("Circuits.UART.configure/2")
+  def flush(_pid), do: forbid("Circuits.UART.flush/1")
+  def flush(_pid, _direction), do: forbid("Circuits.UART.flush/2")
+
+  defp forbid(call) do
+    raise """
+    Real #{call} was called from a test.
+
+    Tests must not touch real serial hardware. Stub explicitly with Mimic:
+
+        expect(Circuits.UART, :open, fn _pid, _port, _opts -> {:ok, self()} end)
+
+    Or use a higher-level helper from Trenino.SerialTestHelpers.
+    """
+  end
+end
+
+defmodule Trenino.Test.ForbiddenAvrdude do
+  @moduledoc """
+  Default Mimic stub for Trenino.Firmware.Avrdude and AvrdudeRunner.
+  Raises on any call so tests that forget to stub avrdude fail loudly
+  instead of spawning real subprocesses.
+  """
+
+  # Trenino.Firmware.Avrdude surface
+  def executable_path, do: forbid("Avrdude.executable_path/0")
+  def executable_path!, do: forbid("Avrdude.executable_path!/0")
+  def available?, do: forbid("Avrdude.available?/0")
+  def version, do: forbid("Avrdude.version/0")
+  def conf_path, do: forbid("Avrdude.conf_path/0")
+
+  # Trenino.Firmware.AvrdudeRunner surface
+  def run(_avrdude_path, _args, _progress_callback),
+    do: forbid("AvrdudeRunner.run/3")
+
+  defp forbid(call) do
+    raise """
+    Real #{call} was called from a test.
+
+    Tests must not spawn real avrdude subprocesses. Stub explicitly:
+
+        expect(Trenino.Firmware.AvrdudeRunner, :run, fn _, _, _ -> {:ok, "ok"} end)
+    """
+  end
+end
+
+defmodule Trenino.Test.ForbiddenSerialDiscovery do
+  @moduledoc """
+  Default Mimic stub for Trenino.Serial.Discovery. Raises on any call.
+  """
+
+  def discover(_uart_pid, _opts), do: forbid("Trenino.Serial.Discovery.discover/2")
+
+  defp forbid(call) do
+    raise """
+    Real #{call} was called from a test.
+
+    Tests must not perform real device discovery. Stub explicitly:
+
+        expect(Trenino.Serial.Discovery, :discover, fn _pid, _opts ->
+          {:ok, %Trenino.Serial.Protocol.IdentityResponse{...}}
+        end)
+    """
+  end
+end
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `mix compile --warnings-as-errors`
+Expected: clean compile.
+
+- [ ] **Step 3: Verify the stub function arities match the real modules**
+
+Run:
+```bash
+mix run -e '
+  for {real, fake} <- [
+    {Circuits.UART, Trenino.Test.ForbiddenUART},
+    {Trenino.Firmware.Avrdude, Trenino.Test.ForbiddenAvrdude},
+    {Trenino.Firmware.AvrdudeRunner, Trenino.Test.ForbiddenAvrdude},
+    {Trenino.Serial.Discovery, Trenino.Test.ForbiddenSerialDiscovery}
+  ] do
+    real_funs = real.__info__(:functions) |> Enum.filter(fn {n, _} -> not String.starts_with?(Atom.to_string(n), "_") end) |> MapSet.new()
+    fake_funs = fake.__info__(:functions) |> MapSet.new()
+    missing = MapSet.difference(real_funs, fake_funs)
+    if MapSet.size(missing) > 0 do
+      IO.puts("MISSING in #{inspect(fake)}: #{inspect(MapSet.to_list(missing))}")
+    end
+  end
+'
+```
+Expected: no `MISSING` lines for `Circuits.UART`, `Trenino.Firmware.AvrdudeRunner`, `Trenino.Serial.Discovery`. For `Trenino.Firmware.Avrdude`, only the public functions documented in the spec need to be stubbed; if `MISSING` lists any extra public functions, add them to `ForbiddenAvrdude`.
+
+If anything is missing, add it to the appropriate stub module and re-run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/support/forbidden_serial.ex
+git commit -m "test: add forbidden default Mimic stubs for serial/avrdude
+
+Three modules — ForbiddenUART, ForbiddenAvrdude, ForbiddenSerialDiscovery —
+that raise loudly on any call. Wired up in case templates in next commit;
+this commit is the inert addition.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Wire forbidden stubs into DataCase and ConnCase
+
+**Files:**
+- Modify: `test/support/data_case.ex`
+- Modify: `test/support/conn_case.ex`
+
+- [ ] **Step 1: Update DataCase**
+
+In `test/support/data_case.ex`, replace the existing `setup tags do` block with:
+
+```elixir
+  setup tags do
+    Trenino.DataCase.setup_sandbox(tags)
+    Trenino.DataCase.setup_forbidden_serial_stubs()
+    :ok
+  end
+
+  @doc """
+  Installs default Mimic stubs that forbid real serial / avrdude / discovery
+  access. Tests that legitimately need to simulate one of these subsystems
+  override the default with `Mimic.expect/3` or `Mimic.stub/3`.
+  """
+  def setup_forbidden_serial_stubs do
+    Mimic.set_mimic_private(self())
+    Mimic.stub_with(Circuits.UART, Trenino.Test.ForbiddenUART)
+    Mimic.stub_with(Trenino.Firmware.Avrdude, Trenino.Test.ForbiddenAvrdude)
+    Mimic.stub_with(Trenino.Firmware.AvrdudeRunner, Trenino.Test.ForbiddenAvrdude)
+    Mimic.stub_with(Trenino.Serial.Discovery, Trenino.Test.ForbiddenSerialDiscovery)
+    :ok
+  end
+```
+
+Inside the `using do … quote do` block, add `use Mimic` so test modules importing `DataCase` get Mimic's helpers automatically:
+
+```elixir
+  using do
+    quote do
+      alias Trenino.Repo
+
+      import Ecto
+      import Ecto.Changeset
+      import Ecto.Query
+      import Trenino.DataCase
+
+      use Mimic
+    end
+  end
+```
+
+- [ ] **Step 2: Update ConnCase**
+
+In `test/support/conn_case.ex`, replace the `setup tags do` block with:
+
+```elixir
+  setup tags do
+    Trenino.DataCase.setup_sandbox(tags)
+    Trenino.DataCase.setup_forbidden_serial_stubs()
+    {:ok, conn: Phoenix.ConnTest.build_conn()}
+  end
+```
+
+Inside the `using do` block, add `use Mimic`:
+
+```elixir
+  using do
+    quote do
+      @endpoint TreninoWeb.Endpoint
+
+      use TreninoWeb, :verified_routes
+      use Mimic
+
+      import Plug.Conn
+      import Phoenix.ConnTest
+      import TreninoWeb.ConnCase
+    end
+  end
+```
+
+- [ ] **Step 3: Run a small sample to confirm wiring works**
+
+Run: `mix test test/trenino/firmware/uploader_test.exs --max-failures 5`
+Expected: passes (existing test already uses Mimic and should override the forbidden defaults).
+
+- [ ] **Step 4: Run the full suite, capture failures from forbidden stubs firing**
+
+Run: `mix test 2>&1 | tee /tmp/forbidden-audit.log`
+Expected: many failures with `"Real Circuits.UART.* was called from a test"` or `"Real Avrdude.* was called from a test"`. **This is success** — every such failure is a real safety bug we are now catching.
+
+Save the list of failing files for Task 3:
+```bash
+grep -B1 'Real Circuits\.UART\|Real Avrdude\|Real Trenino\.Serial\.Discovery' /tmp/forbidden-audit.log | grep -oE 'test/[^:]*\.exs' | sort -u > /tmp/forbidden-files.txt
+cat /tmp/forbidden-files.txt
+```
+
+- [ ] **Step 5: Commit (red, on purpose)**
+
+```bash
+git add test/support/data_case.ex test/support/conn_case.ex
+git commit -m "test: wire forbidden serial stubs into DataCase and ConnCase
+
+Every DataCase / ConnCase test now starts with default Mimic stubs that
+raise on any real Circuits.UART / Avrdude / Serial.Discovery call. Tests
+that need real-looking behavior must stub explicitly. Failing tests
+surface in the next commit's fix sweep.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add SerialSafetyCase and fix surfaced failures
+
+**Files:**
+- Create: `test/support/serial_safety_case.ex`
+- Modify: each file in `/tmp/forbidden-files.txt` from Task 2 Step 4
+
+- [ ] **Step 1: Create SerialSafetyCase template**
+
+Write `test/support/serial_safety_case.ex`:
+
+```elixir
+defmodule Trenino.SerialSafetyCase do
+  @moduledoc """
+  Test case template for plain ExUnit.Case files that exercise serial /
+  avrdude / discovery code paths but do not need the database sandbox.
+
+  Installs the same forbidden default Mimic stubs as DataCase so accidental
+  hardware access raises loudly.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using opts do
+    async = Keyword.get(opts, :async, true)
+
+    quote do
+      use ExUnit.Case, async: unquote(async)
+      use Mimic
+    end
+  end
+
+  setup do
+    Trenino.DataCase.setup_forbidden_serial_stubs()
+    :ok
+  end
+end
+```
+
+- [ ] **Step 2: For each file in `/tmp/forbidden-files.txt`, decide and apply**
+
+For each file, the fix is one of:
+
+**A. The test never legitimately needs UART** — convert `use ExUnit.Case` → `use Trenino.SerialSafetyCase`. The test now inherits the forbidden defaults. If the test was already correct, no further change.
+
+**B. The test legitimately calls UART code** (e.g. exercises a function that internally calls `Circuits.UART.enumerate`) — add per-test `Mimic.expect/3` or `Mimic.stub/3` overrides. Example:
+
+```elixir
+test "scan returns empty list when no devices" do
+  Mimic.expect(Circuits.UART, :enumerate, fn -> %{} end)
+
+  assert [] = Trenino.Serial.Connection.scan()
+end
+```
+
+**C. The test was already using DataCase/ConnCase but spawned a process** (e.g. `Task.async`) **that hit the forbidden stub** — use `Mimic.set_mimic_global` for that test (`@tag :async_false_required`) or use `Mimic.allow/3` to grant the spawned process access to the parent's stubs:
+
+```elixir
+test "task scenario" do
+  parent = self()
+  Mimic.expect(Circuits.UART, :enumerate, fn -> %{} end)
+
+  task = Task.async(fn ->
+    Mimic.allow(Circuits.UART, parent, self())
+    Trenino.Serial.Connection.scan()
+  end)
+
+  assert [] = Task.await(task)
+end
+```
+
+- [ ] **Step 3: Re-run the suite until green**
+
+Run: `mix test`
+Expected: all tests pass. If any forbidden-stub failures remain, repeat Step 2 for those files.
+
+- [ ] **Step 4: Verify safety net still active**
+
+Run a quick sanity check:
+```bash
+mix run -e '
+  IO.inspect(Trenino.Test.ForbiddenUART.enumerate())
+' 2>&1 | head -3
+```
+This should fail with the forbidden-call message (proving the stub module is loaded and ready, not that the suite uses it; the suite uses it via Mimic).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A test/
+git commit -m "test: add SerialSafetyCase and fix tests caught by forbidden stubs
+
+Every test now passes through forbidden defaults; cases that exercised
+real serial/avrdude paths now have explicit Mimic expectations or
+inherit SerialSafetyCase.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: PubSub subscriber wait helper
+
+**Files:**
+- Create: `test/support/pubsub_helpers.ex`
+
+- [ ] **Step 1: Verify how Phoenix.PubSub tracks subscribers**
+
+Run:
+```bash
+mix run -e '
+  Phoenix.PubSub.subscribe(Trenino.PubSub, "test:topic")
+  IO.inspect(Registry.lookup(Trenino.PubSub, "test:topic"))
+'
+```
+
+Expected: a non-empty list of `{pid, value}` tuples. If empty, the local registry has a different name. Inspect `Phoenix.PubSub` adapter config in `lib/trenino/application.ex:21` and find the actual registry name. Common alternatives: `Trenino.PubSub.Local`, `Trenino.PubSub.Adapter`. Adjust the helper in Step 2 accordingly.
+
+- [ ] **Step 2: Write the helper**
+
+Write `test/support/pubsub_helpers.ex`:
+
+```elixir
+defmodule Trenino.PubSubHelpers do
+  @moduledoc """
+  Test-only helpers for synchronizing on Phoenix.PubSub state.
+
+  Replaces `Process.sleep/1`-based race patterns where a test broadcasts
+  to a topic and assumes a freshly-spawned subscriber is ready in time.
+  """
+
+  @doc """
+  Block until at least one process is subscribed to `topic`, or the timeout
+  expires.
+
+  Returns `:ok` on success or `{:error, :timeout}`.
+
+  ## Example
+
+      task = Task.async(fn -> SomeGenServer.subscribe_and_wait() end)
+      :ok = wait_for_subscriber("hardware:input_values:test_port")
+      Phoenix.PubSub.broadcast(Trenino.PubSub, "hardware:input_values:test_port", :event)
+      assert {:ok, _} = Task.await(task, 1_000)
+  """
+  @spec wait_for_subscriber(String.t(), pos_integer()) :: :ok | {:error, :timeout}
+  def wait_for_subscriber(topic, timeout_ms \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait(topic, deadline)
+  end
+
+  defp do_wait(topic, deadline) do
+    if has_subscriber?(topic) do
+      :ok
+    else
+      if System.monotonic_time(:millisecond) > deadline do
+        {:error, :timeout}
+      else
+        Process.sleep(5)
+        do_wait(topic, deadline)
+      end
+    end
+  end
+
+  defp has_subscriber?(topic) do
+    case Registry.lookup(Trenino.PubSub, topic) do
+      [] -> false
+      [_ | _] -> true
+    end
+  end
+end
+```
+
+If Step 1 found a different registry name, replace `Trenino.PubSub` in the `Registry.lookup/2` call accordingly.
+
+- [ ] **Step 3: Smoke test the helper**
+
+Run:
+```bash
+mix run -e '
+  spawn(fn ->
+    Phoenix.PubSub.subscribe(Trenino.PubSub, "smoke:test")
+    Process.sleep(:infinity)
+  end)
+  Process.sleep(20)
+  IO.inspect(Trenino.PubSubHelpers.wait_for_subscriber("smoke:test", 500))
+'
+```
+Expected: `:ok`.
+
+Also verify timeout path:
+```bash
+mix run -e 'IO.inspect(Trenino.PubSubHelpers.wait_for_subscriber("nonexistent:topic", 100))'
+```
+Expected: `{:error, :timeout}`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/support/pubsub_helpers.ex
+git commit -m "test: add wait_for_subscriber/2 PubSub sync helper
+
+Replaces Process.sleep-based race patterns in tests that broadcast
+to a topic and assume a freshly-spawned subscriber is ready.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Fix detection-tools flake
+
+**Files:**
+- Modify: `test/trenino/mcp/tools/detection_tools_test.exs`
+
+- [ ] **Step 1: Reproduce the flake**
+
+Run:
+```bash
+for i in 1 2 3 4 5; do mix test 2>&1 | tail -3; done
+```
+Expected: at least one of the 5 runs shows failures in `Trenino.MCP.Tools.DetectionToolsTest`. This confirms the flake before we fix it.
+
+- [ ] **Step 2: Add helper import to the test file**
+
+In `test/trenino/mcp/tools/detection_tools_test.exs`, add after the existing `alias` lines (around line 6):
+
+```elixir
+  import Trenino.PubSubHelpers, only: [wait_for_subscriber: 1]
+```
+
+- [ ] **Step 3: Replace the `Process.sleep(50)` calls**
+
+`InputDetectionSession` subscribes to `"hardware:input_values:test_port"` (see `lib/trenino/hardware/input_detection_session.ex:237`). Find every `Process.sleep(50)` in `detection_tools_test.exs` (lines 57, 83, 157 per the audit) and replace with:
+
+```elixir
+      :ok = wait_for_subscriber("hardware:input_values:#{@test_port}")
+```
+
+For each affected test, also tighten the `Task.await` timeout from 2000–3000ms down to 1000ms — the wait is now deterministic and any timeout indicates a real bug, not a race.
+
+- [ ] **Step 4: Run the test file 20× to confirm zero flakes**
+
+Run:
+```bash
+for i in $(seq 1 20); do
+  mix test test/trenino/mcp/tools/detection_tools_test.exs 2>&1 | tail -1
+done
+```
+Expected: 20 lines, all `0 failures`.
+
+- [ ] **Step 5: Run the full suite to confirm no regressions**
+
+Run: `mix test`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/trenino/mcp/tools/detection_tools_test.exs
+git commit -m "test: replace detection-tools sleep-races with deterministic sync
+
+Test broadcast no longer assumes the GenServer subscribed within 50ms
+of Task.async; instead waits for the subscriber to register on the
+PubSub topic (typically ~5ms) before broadcasting.
+
+Eliminates 12 flaky failures observed under full-suite load.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Speed up configuration_list_live tests
+
+**Files:**
+- Modify: `test/trenino_web/live/configuration_list_live_test.exs`
+
+These 7 tests cost ~35s. Pattern: `live(conn, ~p"/")` mounts a LiveView whose nav-hook calls `Trenino.Serial.Connection.scan/0` (or related), which is a `GenServer.call` to the connection process. Without a Mimic stub on `Circuits.UART.enumerate`, the GenServer either times out (5s) or blocks until something completes.
+
+- [ ] **Step 1: Reproduce and time the file**
+
+Run:
+```bash
+mix test test/trenino_web/live/configuration_list_live_test.exs --slowest 10
+```
+Note the wall-clock time and the per-test timings.
+
+- [ ] **Step 2: Identify the blocking call**
+
+Inspect what the LiveView `mount/3` (and any `on_mount` hook in `lib/trenino_web/components/`) calls. Look for:
+- `Trenino.Serial.Connection.scan/0` (GenServer.call with default 5000ms timeout)
+- `Trenino.Serial.Connection.connected_devices/0` (similar)
+- `Trenino.Simulator.Connection.get_status/0`
+
+Run:
+```bash
+grep -rEn "Connection\.|Simulator\." lib/trenino_web/components/*.ex lib/trenino_web/live/configuration_list_live.ex | head -20
+```
+
+Whichever GenServer.call is blocking is the one to stub.
+
+- [ ] **Step 3: Add an `on_mount`-level stub setup**
+
+In `test/trenino_web/live/configuration_list_live_test.exs`, add a `setup` block (above `describe "basic rendering"`, after the existing `Sandbox.mode` setup) that stubs the relevant calls. Example for `Connection.scan`:
+
+```elixir
+  setup do
+    # Stub serial enumeration so LiveView mount doesn't block on a 5s
+    # GenServer.call timeout when no real devices are present.
+    Mimic.stub(Circuits.UART, :enumerate, fn -> %{} end)
+
+    # If the LiveView nav-hook calls Connection.scan via GenServer.call:
+    Mimic.stub(Trenino.Serial.Connection, :scan, fn -> :ok end)
+    Mimic.stub(Trenino.Serial.Connection, :connected_devices, fn -> [] end)
+
+    :ok
+  end
+```
+
+If `Trenino.Serial.Connection` is not yet in `Mimic.copy/1` (check `test/test_helper.exs`), add it. Verify by running the file again.
+
+- [ ] **Step 4: Run and confirm speedup**
+
+Run: `mix test test/trenino_web/live/configuration_list_live_test.exs --slowest 10`
+Expected: total wall-clock drops from ~5s/test to <500ms/test. File should complete in under 5s total.
+
+- [ ] **Step 5: Run full suite to verify no regressions**
+
+Run: `mix test`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/trenino_web/live/configuration_list_live_test.exs
+git commit -m "test: stub serial calls in configuration_list_live_test
+
+Mount-time GenServer.call to Connection.scan was timing out at 5000ms
+per test (no real devices present). Stubbing Connection at the test
+boundary cuts ~30s off this file alone.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Speed up BLDC controller tests
+
+**Files:**
+- Modify: `test/trenino/train/lever_controller_bldc_test.exs`
+- Modify: `test/trenino/integration/bldc_lever_flow_test.exs`
+
+7 tests across these two files cost ~35s. Pattern: a `Process.sleep(5_000)` waits for "BLDC profile to load" (an async Task spawned by the lever controller).
+
+- [ ] **Step 1: Identify the actual signal**
+
+Run:
+```bash
+grep -nE "Process\.sleep\(5_?000|profile.*load|broadcast.*profile" test/trenino/train/lever_controller_bldc_test.exs test/trenino/integration/bldc_lever_flow_test.exs lib/trenino/train/lever_controller.ex 2>/dev/null
+```
+
+Find what topic / message the `LeverController` broadcasts when the profile finishes loading. Likely candidates:
+- A `Phoenix.PubSub.broadcast` to `"train:lever_profile:#{train_id}"` with `{:profile_loaded, ...}`.
+- A direct `send(parent_pid, ...)`.
+- A state change observable via `:sys.get_state/1`.
+
+- [ ] **Step 2: Replace each `Process.sleep(5_000)` with the actual wait**
+
+If the controller broadcasts to a PubSub topic, in each test:
+
+```elixir
+# Before:
+# Process.sleep(5_000)
+
+# After (PubSub case):
+Phoenix.PubSub.subscribe(Trenino.PubSub, "train:lever_profile:#{train_id}")
+# … trigger the action that loads the profile …
+assert_receive {:profile_loaded, _profile}, 1_000
+```
+
+Or, if the load is wrapped in a `Task` that the test can `await` directly, do that instead.
+
+- [ ] **Step 3: Run each file independently**
+
+```bash
+mix test test/trenino/train/lever_controller_bldc_test.exs --slowest 10
+mix test test/trenino/integration/bldc_lever_flow_test.exs --slowest 10
+```
+Expected: per-test cost drops from 5000ms to <500ms.
+
+- [ ] **Step 4: Run full suite to verify no regressions**
+
+Run: `mix test`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/trenino/train/lever_controller_bldc_test.exs test/trenino/integration/bldc_lever_flow_test.exs
+git commit -m "test: replace 5s sleeps with PubSub assertions in BLDC tests
+
+Was waiting a fixed 5s for an async profile load; now subscribes to the
+actual broadcast topic and asserts within 1s.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Speed up connection_port_timeout tests
+
+**Files:**
+- Modify: `test/trenino/serial/connection_port_timeout_test.exs`
+- Possibly modify: `lib/trenino/serial/connection.ex` (only if the timeout is hard-coded; adding `Application.get_env` is fine)
+
+2 tests cost 12.6s, intentionally simulating a slow GenServer. We can keep the test intent (cover the timeout path) while halving wall-clock time by making the timeout configurable.
+
+- [ ] **Step 1: Read the test and identify the hard-coded timeout**
+
+Run:
+```bash
+sed -n '1,200p' test/trenino/serial/connection_port_timeout_test.exs
+```
+Find where the test simulates a slow operation (likely `Process.sleep(5_500)` or similar) and what timeout it's asserting fires.
+
+- [ ] **Step 2: Make the production timeout config-driven**
+
+In `lib/trenino/serial/connection.ex`, find the relevant `GenServer.call` timeout (probably 5000ms). Replace with:
+
+```elixir
+@default_call_timeout_ms 5_000
+
+defp call_timeout do
+  Application.get_env(:trenino, :serial_connection_call_timeout_ms, @default_call_timeout_ms)
+end
+```
+
+And use `call_timeout()` at the call site. Add `:serial_connection_call_timeout_ms` to `config/test.exs` set to `500`.
+
+- [ ] **Step 3: Halve the simulated delay in the test**
+
+Update the test's simulated sleep to match (e.g. `Process.sleep(600)` instead of `Process.sleep(5_500)`).
+
+- [ ] **Step 4: Run the file**
+
+Run: `mix test test/trenino/serial/connection_port_timeout_test.exs --slowest 5`
+Expected: total under 2s.
+
+- [ ] **Step 5: Run full suite**
+
+Run: `mix test`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/trenino/serial/connection_port_timeout_test.exs lib/trenino/serial/connection.ex config/test.exs
+git commit -m "test: make serial connection call timeout config-driven
+
+Connection.call timeout is now Application-configurable; test env uses
+500ms instead of 5000ms, halving the wall-clock cost of the timeout
+regression tests without changing what they cover.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Output hygiene — demote startup error log
+
+**Files:**
+- Modify: `lib/trenino/firmware/device_registry.ex`
+
+- [ ] **Step 1: Find and demote the manifest-fallback log**
+
+In `lib/trenino/firmware/device_registry.ex`, find the line that emits `"No firmware release manifest available..."` (around lines 212–218). Confirm it's the one emitted on a fresh install / empty database (an expected fallback, not an error).
+
+Change `Logger.warning(` → `Logger.info(` at that call site only. Do not touch other warnings in the same file unless they're similarly expected-fallback logs.
+
+- [ ] **Step 2: Verify clean test output**
+
+Run: `mix test 2>&1 | grep -E "^\\[(error|warning)\\]"`
+Expected: zero matches. (If matches remain, the `silently/1` step in Task 10 will cover them.)
+
+- [ ] **Step 3: Confirm tests still pass**
+
+Run: `mix test`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/trenino/firmware/device_registry.ex
+git commit -m "fix: demote 'no manifest' startup log from warning to info
+
+The 'no firmware release manifest available' log fires on every fresh
+install (and every test run) before a manifest is fetched. It's the
+expected fallback path, not an error condition.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Output hygiene — silently/1 helper for intentional warning paths
+
+**Files:**
+- Modify: `test/support/data_case.ex`
+- Possibly modify: any test file whose intentional-error paths still leak `Logger.warning` lines
+
+- [ ] **Step 1: Add the helper**
+
+In `test/support/data_case.ex`, add to the `using do` quote:
+
+```elixir
+      import Trenino.DataCase, only: [errors_on: 1, silently: 1]
+```
+
+(Or extend the existing import if there is one.)
+
+And add the function definition next to `errors_on/1`:
+
+```elixir
+  @doc """
+  Captures Logger output during the given function. Use to wrap calls
+  in tests that intentionally exercise error/cleanup paths and would
+  otherwise leak [warning]/[error] lines into the test output.
+
+      silently(fn -> Connection.handle_decode_failure(garbage) end)
+  """
+  def silently(fun) when is_function(fun, 0) do
+    ExUnit.CaptureLog.capture_log(fun)
+  end
+```
+
+- [ ] **Step 2: Find remaining log leaks and wrap them**
+
+Run: `mix test 2>&1 | grep -E "^\\[(error|warning)\\]" | sort -u`
+For each unique log line, find the test that triggers it and wrap the offending call in `silently(fn -> ... end)`. Be conservative: only wrap calls that are *intentionally* exercising the error path.
+
+- [ ] **Step 3: Verify clean output**
+
+Run: `mix test 2>&1 | grep -E "^\\[(error|warning)\\]" | wc -l`
+Expected: `0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A test/
+git commit -m "test: add silently/1 helper and wrap intentional warning paths
+
+Tests that intentionally exercise error/cleanup paths now wrap their
+Logger-emitting calls in silently/1, eliminating noise from clean runs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Compile-warning sweep
+
+**Files:**
+- Possibly modify: any source file with a compile warning
+
+- [ ] **Step 1: Surface all compile warnings**
+
+Run: `mix compile --warnings-as-errors --force 2>&1 | tee /tmp/compile-warnings.log`
+Expected: clean compile, OR a list of warnings to address.
+
+- [ ] **Step 2: Fix each warning**
+
+For each warning, fix the underlying issue. Common categories:
+- Unused variable → prefix with `_`.
+- Unused alias / import → remove.
+- Deprecated function → replace with current API.
+- Pattern match never matches → restructure.
+
+Do not silence with `@compile {:no_warn_undefined, ...}` unless the warning is genuinely unfixable (e.g., optional dependency).
+
+- [ ] **Step 3: Verify clean compile**
+
+Run: `mix compile --warnings-as-errors --force`
+Expected: clean.
+
+- [ ] **Step 4: Run full suite**
+
+Run: `mix test`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "fix: resolve compile warnings surfaced by --warnings-as-errors
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+If no warnings existed (Step 1 was already clean), skip this commit.
+
+---
+
+## Task 12: Final verification
+
+- [ ] **Step 1: Run `mix precommit` 3× back-to-back**
+
+```bash
+for i in 1 2 3; do
+  echo "=== Run $i ==="
+  mix precommit 2>&1 | tail -10
+done
+```
+Expected: 3 clean runs, each with `0 failures`.
+
+- [ ] **Step 2: Confirm runtime target**
+
+Run: `mix test --slowest 10 2>&1 | tail -20`
+Expected: `Finished in <60.0> seconds` and the slowest 10 tests should each be under 1 second.
+
+- [ ] **Step 3: Confirm no real-serial regressions**
+
+Run: `grep -rE "Circuits\.UART\.|System\.cmd.*avrdude" lib/ | wc -l`
+Compare against the pre-change count (should be **identical** — we did no production refactor for serial calls; the only production change is the `device_registry.ex` log demotion and the optional `connection.ex` config read).
+
+- [ ] **Step 4: Confirm clean output**
+
+Run: `mix test 2>&1 | grep -E "^\\[(error|warning)\\]" | wc -l`
+Expected: `0`.
+
+- [ ] **Step 5: Confirm zero flakes**
+
+Run: `for i in $(seq 1 5); do mix test 2>&1 | tail -1; done`
+Expected: 5 lines, all `0 failures`.
+
+- [ ] **Step 6: Final commit (if any cleanup needed) or close out**
+
+If any small fixes were needed during verification, commit them. Otherwise, the plan is complete — the branch is ready to PR/merge.
+
+---
+
+## Summary of Verification Gates
+
+All must pass before declaring done:
+
+| Gate | Command | Expected |
+|---|---|---|
+| Runtime | `mix test` | < 60s |
+| Flakes | `for i in $(seq 1 5); do mix test 2>&1 \| tail -1; done` | 5× `0 failures` |
+| No production refactor | `grep -rE "Circuits\\.UART\\.\|System\\.cmd.*avrdude" lib/ \| wc -l` | unchanged |
+| Clean output | `mix test 2>&1 \| grep -E "^\\[(error\|warning)\\]" \| wc -l` | `0` |
+| Compile clean | `mix compile --warnings-as-errors --force` | clean |
+| precommit | `mix precommit` 3× | all green |

--- a/docs/superpowers/specs/2026-05-03-test-suite-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-03-test-suite-cleanup-design.md
@@ -1,0 +1,238 @@
+# Test Suite Cleanup — Design
+
+**Date:** 2026-05-03
+**Branch:** feature/firmware-flashing-robustness (or follow-up)
+**Status:** Draft, awaiting user review
+
+## Problem
+
+The test suite has four interrelated quality issues:
+
+1. **Fragile.** 12 tests in `test/trenino/mcp/tools/detection_tools_test.exs` fail intermittently in the full suite but pass in isolation. Cause: `Process.sleep(50)` followed by a PubSub broadcast that races the GenServer's subscription.
+2. **Unsafe.** `Circuits.UART`, `Trenino.Serial.Discovery`, and `Trenino.Firmware.Avrdude{,Runner}` are `Mimic.copy`'d in `test_helper.exs`, but only intercepted in tests that explicitly stub them. A test that forgets to stub can call the real serial/avrdude subsystem.
+3. **Slow.** `mix test` takes 218s end-to-end. Top 25 slowest tests = 91s out of 102s of clean-run time (89%). Five files dominate: `configuration_list_live_test.exs` (35s), `lever_controller_bldc_test.exs` (20s), `bldc_lever_flow_test.exs` (15s), `connection_port_timeout_test.exs` (12.6s), `upload_flow_test.exs` Windows scenario (0.78s).
+4. **Verbose.** Successful runs emit `[error]` lines (e.g. `"No firmware release manifest available"`) and per-test `Logger.warning` calls, padding output with non-actionable noise.
+
+## Goals
+
+1. **Hard guarantee:** no test calls real `Circuits.UART`, `Trenino.Firmware.Avrdude`, `Trenino.Firmware.AvrdudeRunner`, or `Trenino.Serial.Discovery`. Accidental calls raise a clear, on-purpose error.
+2. **Suite runtime under 60 seconds** on a developer laptop.
+3. **Zero flakes** in the detection-tools file across 5 consecutive `mix test` runs.
+4. **Clean output** — no `[error]` / `[warning]` log lines on success, no compile warnings.
+
+## Non-goals
+
+- No production-code adapter behaviour. Mimic-based safety net only.
+- No suite-wide async audit. Convert sync→async only where it falls out for free.
+- No deletion of tests; assertions stay.
+- No CI infrastructure changes (partitioning, parallel jobs, etc.).
+
+## Architecture
+
+### 1. Global serial/avrdude safety net
+
+Add a new test-support module that defines forbidden default stubs:
+
+```elixir
+# test/support/forbidden_serial.ex
+defmodule Trenino.Test.ForbiddenUART do
+  @moduledoc false
+  def open(_, _, _),    do: forbid("Circuits.UART.open/3")
+  def close(_),         do: forbid("Circuits.UART.close/1")
+  def write(_, _),      do: forbid("Circuits.UART.write/2")
+  def read(_, _),       do: forbid("Circuits.UART.read/2")
+  def enumerate,        do: forbid("Circuits.UART.enumerate/0")
+  def start_link,       do: forbid("Circuits.UART.start_link/0")
+  def controlling_process(_, _), do: forbid("Circuits.UART.controlling_process/2")
+
+  defp forbid(call) do
+    raise """
+    Real #{call} was called from a test.
+
+    Stub it explicitly with Mimic, e.g.:
+        expect(Circuits.UART, :open, fn _, _, _ -> {:ok, self()} end)
+
+    Or use a Trenino.SerialTestHelpers builder for higher-level fakes.
+    """
+  end
+end
+
+defmodule Trenino.Test.ForbiddenAvrdude do
+  @moduledoc false
+  def upload(_, _),     do: forbid("Avrdude.upload/2")
+  # … cover every public function on Avrdude / AvrdudeRunner
+end
+
+defmodule Trenino.Test.ForbiddenSerialDiscovery do
+  @moduledoc false
+  def discover(_, _),   do: forbid("Trenino.Serial.Discovery.discover/2")
+end
+```
+
+Wire defaults in a shared setup block (`Trenino.DataCase`, `Trenino.ConnCase`, and a new `Trenino.SerialSafetyCase` for plain-`ExUnit.Case` files), invoked per-test:
+
+```elixir
+# in DataCase / ConnCase / SerialSafetyCase setup
+setup :set_mimic_private
+setup do
+  Mimic.stub_with(Circuits.UART, Trenino.Test.ForbiddenUART)
+  Mimic.stub_with(Trenino.Firmware.Avrdude, Trenino.Test.ForbiddenAvrdude)
+  Mimic.stub_with(Trenino.Firmware.AvrdudeRunner, Trenino.Test.ForbiddenAvrdude)
+  Mimic.stub_with(Trenino.Serial.Discovery, Trenino.Test.ForbiddenSerialDiscovery)
+  :ok
+end
+```
+
+Why per-test setup, not `test_helper.exs`: Mimic distinguishes `:private` (process-local, async-safe) from `:global` (BEAM-wide, requires `async: false`). Setting stubs in `test_helper.exs` would require `:global` mode, which conflicts with async tests. Per-test `:private` stubs apply to the test process and any process it spawns via `Mimic.allow/3`, and tests' own `expect/3` calls override the forbidden defaults transparently.
+
+**Implementation note:** verify Mimic's exact behaviour for `stub_with` under `:private` mode against the installed version (`mix hex.info mimic`) before wiring. If `stub_with` cannot be re-applied per-test, fall back to a `Mimic.stub/3` per function.
+
+Tests using bare `ExUnit.Case` (no Mimic) that exercise UART code paths will surface as failures when their owning module is moved onto `SerialSafetyCase`. For each such file we add `use Mimic` and a per-test `expect/3`. Audit list built during step 1 of implementation.
+
+### 2. Detection-tools deterministic synchronization
+
+Add a PubSub-aware wait helper:
+
+```elixir
+# test/support/pubsub_helpers.ex
+defmodule Trenino.PubSubHelpers do
+  @moduledoc false
+  alias Phoenix.PubSub
+
+  @pubsub Trenino.PubSub
+
+  @doc """
+  Block until at least one process has subscribed to `topic`, or timeout.
+  Polls Phoenix.PubSub's local registry every 5ms.
+  """
+  def wait_for_subscriber(topic, timeout_ms \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait(topic, deadline)
+  end
+
+  defp do_wait(topic, deadline) do
+    if has_subscriber?(topic) do
+      :ok
+    else
+      if System.monotonic_time(:millisecond) > deadline do
+        {:error, :timeout}
+      else
+        Process.sleep(5)
+        do_wait(topic, deadline)
+      end
+    end
+  end
+
+  defp has_subscriber?(topic) do
+    # Phoenix.PubSub.PG2 registers subscribers in a Registry keyed by topic
+    case Registry.lookup(Trenino.PubSub, topic) do
+      [] -> false
+      [_ | _] -> true
+    end
+  end
+end
+```
+
+(Exact registry name will be verified during implementation against the running PubSub adapter.)
+
+Refactor each affected detection-tools test:
+
+```elixir
+task = Task.async(fn -> DetectionTools.execute(...) end)
+:ok = wait_for_subscriber("hardware:input_values:#{@test_port}")
+broadcast_input(button.pin, 0)
+broadcast_input(button.pin, 1)
+assert {:ok, result} = Task.await(task, 1_000)  # tighter timeout, deterministic
+```
+
+### 3. Slow-test surgery (top 5 files)
+
+| File | Current cost | Pattern | Fix |
+|---|---|---|---|
+| `test/trenino_web/live/configuration_list_live_test.exs` | 35s (7 tests) | `assert_receive {:simulator_status, _}, 5_000` after a `Process.sleep`-driven status loop. | Trigger status updates via direct `PubSub.broadcast` in test; tighten receive timeout to 200ms. |
+| `test/trenino/train/lever_controller_bldc_test.exs` | 20s (4 tests) | `Process.sleep(5_000)` waiting on Task-loaded BLDC profile. | Await the actual Task, or subscribe to the `lever_profile_loaded` PubSub event. |
+| `test/trenino/integration/bldc_lever_flow_test.exs` | 15s (3 tests) | Same pattern across an integration flow. | Same fix; helper for "wait for profile loaded". |
+| `test/trenino/serial/connection_port_timeout_test.exs` | 12.6s (2 tests) | Test simulates slow GenServer with sleep matching production timeout. | `Application.put_env(:trenino, :connection_timeout_ms, 500)` in test setup; halve the simulated delay. |
+| `test/trenino/firmware/upload_flow_test.exs` | 0.78s | Real polling loop. | Already mimicked. No action. |
+
+Estimated impact: ~83s removed → suite runs in ~20–25s.
+
+### 4. Broader sleep replacement (medium aggression)
+
+Outside the top 5, replace `Process.sleep` only where:
+- It gates an `assert_receive` that can collapse into the receive itself; OR
+- The containing file appears in `mix test --slowest` above 100ms.
+
+Skip cosmetic 10ms sleeps. No file-by-file audit beyond what `--slowest` surfaces.
+
+### 5. Output hygiene
+
+**a) Demote startup error log.** In `lib/trenino/firmware/device_registry.ex` (lines 212–218), change `Logger.warning` → `Logger.info` for the "no manifest, using fallback" path. It's an expected fallback in tests *and* in fresh production installs; not a warning.
+
+**b) Capture intentional warnings.** Add helper to `Trenino.DataCase`:
+
+```elixir
+def silently(fun), do: ExUnit.CaptureLog.capture_log(fun)
+```
+
+Wrap calls in tests that intentionally exercise error/cleanup paths. Audit during implementation; apply only where logs leak.
+
+**c) Compile warnings.** Run `mix compile --warnings-as-errors` once; fix anything surfaced. (Already part of `mix precommit` via `credo --strict` — verify.)
+
+**d) Formatter.** Keep ExUnit's default dot formatter. Failures will be rare and informative once flakes are gone.
+
+Target clean-run output:
+```
+Compiling N files (.ex)
+....................................................................
+Finished in 22.0 seconds
+1346 tests, 0 failures
+```
+
+## Implementation order
+
+Each step is independently committable and verifiable:
+
+1. **Safety net.** Add `forbidden_serial.ex`, wire `Mimic.stub_with` in `test_helper.exs`, set up Mimic in `DataCase`/`ConnCase` setup blocks. Run full suite; fix every test that surfaces by adding `use Mimic` + per-test `expect/3`.
+2. **Detection-tools fix.** Add `wait_for_subscriber/1`; refactor `detection_tools_test.exs`; run that file 20× in a row to confirm zero flakes.
+3. **Top-5 slow-test surgery.** One file per commit, biggest win first. Re-run `mix test --slowest 25` after each to confirm impact.
+4. **Output hygiene.** Demote manifest log, add `silently/1`, run `mix compile --warnings-as-errors`.
+5. **Final verification.** `mix precommit` 3× back-to-back; confirm targets met.
+
+## Verification gates (all must pass before done)
+
+- `mix test` completes in < 60s on developer laptop.
+- 5 consecutive `mix test` runs: zero failures.
+- `grep -rE "Circuits\.UART\.|System\.cmd.*avrdude" lib/` returns the same set of call sites as today (no production refactor).
+- Clean-run output has zero `[error]` and zero `[warning]` log lines.
+- `mix compile --warnings-as-errors` succeeds.
+
+## Files touched (estimate)
+
+**New:**
+- `test/support/forbidden_serial.ex`
+- `test/support/pubsub_helpers.ex`
+- `test/support/serial_safety_case.ex`
+
+**Modified:**
+- `test/support/data_case.ex` (Mimic per-test stubs, `silently/1`)
+- `test/support/conn_case.ex` (Mimic per-test stubs)
+- new `test/support/serial_safety_case.ex` for plain `ExUnit.Case` files that need the safety net
+- `lib/trenino/firmware/device_registry.ex` (one log-level change)
+- `test/trenino/mcp/tools/detection_tools_test.exs` (subscriber handshake)
+- `test/trenino_web/live/configuration_list_live_test.exs` (timeout + sleep removal)
+- `test/trenino/train/lever_controller_bldc_test.exs` (Task await)
+- `test/trenino/integration/bldc_lever_flow_test.exs` (Task await)
+- `test/trenino/serial/connection_port_timeout_test.exs` (config-driven timeout)
+
+Total: ~10 files.
+
+## Rollback
+
+Each step is one commit. Reverting any later step leaves earlier wins intact. Safety net (step 1) and detection fix (step 2) stand independently and can ship even if surgery uncovers blockers.
+
+## Open items resolved during implementation
+
+- Exact `Phoenix.PubSub` registry name for `wait_for_subscriber/1` (verify against running adapter).
+- Full surface of `Trenino.Firmware.Avrdude` / `AvrdudeRunner` public functions to stub.
+- Whether any test legitimately needs the real `Trenino.Serial.Discovery` (audit during step 1).

--- a/lib/trenino/firmware/avrdude_runner.ex
+++ b/lib/trenino/firmware/avrdude_runner.ex
@@ -1,0 +1,71 @@
+defmodule Trenino.Firmware.AvrdudeRunner do
+  @moduledoc """
+  Executes avrdude as a subprocess and collects its output.
+
+  Isolated into its own module so tests can stub it via Mimic,
+  allowing the retry logic in Uploader to be exercised without
+  spawning real processes.
+  """
+
+  @type progress_callback :: (integer(), String.t() -> any())
+
+  @collect_timeout_ms 120_000
+
+  @doc """
+  Runs avrdude with the given arguments and collects all output.
+
+  Returns `{:ok, output}` on exit status 0 or `{:error, output}` on non-zero exit.
+  Calls `progress_callback.(percent, message)` for each progress line detected.
+  """
+  @spec run(String.t(), [String.t()], progress_callback() | nil) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def run(avrdude_path, args, progress_callback) do
+    port =
+      Port.open({:spawn_executable, avrdude_path}, [
+        :binary,
+        :exit_status,
+        :stderr_to_stdout,
+        args: args
+      ])
+
+    collect_output(port, "", progress_callback)
+  end
+
+  defp collect_output(port, acc, progress_callback) do
+    receive do
+      {^port, {:data, data}} ->
+        new_acc = acc <> data
+        if progress_callback, do: parse_progress(data, progress_callback)
+        collect_output(port, new_acc, progress_callback)
+
+      {^port, {:exit_status, 0}} ->
+        {:ok, acc}
+
+      {^port, {:exit_status, _code}} ->
+        {:error, acc}
+    after
+      @collect_timeout_ms ->
+        Port.close(port)
+        {:error, acc <> "\n[Timeout: avrdude did not respond within 2 minutes]"}
+    end
+  end
+
+  defp parse_progress(data, callback) do
+    lines = String.split(data, "\n")
+
+    Enum.each(lines, fn line ->
+      case Regex.run(~r/(Reading|Writing|Verifying)\s+\|.*?\|\s+(\d+)%/, line) do
+        [_, operation, percent_str] ->
+          percent = String.to_integer(percent_str)
+          callback.(percent, format_operation(operation, percent))
+
+        nil ->
+          :ok
+      end
+    end)
+  end
+
+  defp format_operation("Reading", _percent), do: "Reading device..."
+  defp format_operation("Writing", percent), do: "Writing flash (#{percent}%)"
+  defp format_operation("Verifying", percent), do: "Verifying (#{percent}%)"
+end

--- a/lib/trenino/firmware/device_registry.ex
+++ b/lib/trenino/firmware/device_registry.ex
@@ -16,6 +16,7 @@ defmodule Trenino.Firmware.DeviceRegistry do
   alias Trenino.Firmware
 
   @table_name :firmware_device_registry
+  @supported_programmers ~w[arduino avr109 wiring avrisp usbasp]
 
   ## Client API
 
@@ -243,18 +244,26 @@ defmodule Trenino.Firmware.DeviceRegistry do
   end
 
   defp build_device_config(environment, display_name, firmware_file, upload_config) do
-    # Convert manifest field names to internal format
-    # Manifest uses: protocol, mcu, speed, requires1200bpsTouch
-    # Internal uses: programmer, mcu, baud_rate, use_1200bps_touch
-    %{
-      environment: environment,
-      display_name: display_name,
-      firmware_file: firmware_file,
-      mcu: normalize_mcu(upload_config["mcu"]),
-      programmer: upload_config["protocol"],
-      baud_rate: upload_config["speed"],
-      use_1200bps_touch: upload_config["requires1200bpsTouch"] || false
-    }
+    protocol = upload_config["protocol"]
+
+    if protocol in @supported_programmers do
+      %{
+        environment: environment,
+        display_name: display_name,
+        firmware_file: firmware_file,
+        mcu: normalize_mcu(upload_config["mcu"]),
+        programmer: protocol,
+        baud_rate: upload_config["speed"],
+        use_1200bps_touch: upload_config["requires1200bpsTouch"] || false
+      }
+    else
+      Logger.warning(
+        "Skipping device #{environment}: protocol #{inspect(protocol)} is not supported. " <>
+          "Supported protocols: #{Enum.join(@supported_programmers, ", ")}"
+      )
+
+      nil
+    end
   end
 
   # Convert full MCU names from manifest to avrdude short codes
@@ -264,7 +273,6 @@ defmodule Trenino.Firmware.DeviceRegistry do
       "atmega32u4" -> "m32u4"
       "atmega2560" -> "m2560"
       "at91sam3x8e" -> "at91sam3x8e"
-      "esp32" -> "esp32"
       other -> other
     end
   end

--- a/lib/trenino/firmware/device_registry.ex
+++ b/lib/trenino/firmware/device_registry.ex
@@ -292,7 +292,7 @@ defmodule Trenino.Firmware.DeviceRegistry do
   end
 
   defp load_fallback_devices do
-    Logger.error(
+    Logger.info(
       "No firmware release manifest available. " <>
         "Please check for firmware updates to download device configurations. " <>
         "No devices will be available until a release manifest is loaded."

--- a/lib/trenino/firmware/device_registry.ex
+++ b/lib/trenino/firmware/device_registry.ex
@@ -257,7 +257,7 @@ defmodule Trenino.Firmware.DeviceRegistry do
         use_1200bps_touch: upload_config["requires1200bpsTouch"] || false
       }
     else
-      Logger.warning(
+      Logger.info(
         "Skipping device #{environment}: protocol #{inspect(protocol)} is not supported. " <>
           "Supported protocols: #{Enum.join(@supported_programmers, ", ")}"
       )

--- a/lib/trenino/firmware/upload_manager.ex
+++ b/lib/trenino/firmware/upload_manager.ex
@@ -155,7 +155,6 @@ defmodule Trenino.Firmware.UploadManager do
     # Task crashed
     case state.current_upload do
       %{task_ref: ^ref} = upload ->
-        Logger.error("Upload task crashed: #{inspect(reason)}")
         handle_upload_crash(upload, reason)
         {:noreply, %{state | current_upload: nil}}
 
@@ -268,16 +267,25 @@ defmodule Trenino.Firmware.UploadManager do
   end
 
   defp handle_upload_result(upload, {:error, reason, output}) do
-    # Release the port
     Connection.release_upload_access(upload.port, upload.release_token)
 
-    # Update history
     error_message = Uploader.error_message(reason)
 
     case Firmware.get_upload_history(upload.upload_id) do
       {:ok, history} -> Firmware.fail_upload(history, to_string(reason), output)
       _ -> :ok
     end
+
+    Sentry.capture_message("firmware_upload_failed",
+      level: :error,
+      extra: %{
+        upload_id: upload.upload_id,
+        port: upload.port,
+        environment: upload.environment,
+        error_reason: reason,
+        avrdude_output: output
+      }
+    )
 
     broadcast({:upload_failed, upload.upload_id, reason, error_message})
     Logger.error("Failed firmware upload #{upload.upload_id}: #{reason}")
@@ -289,16 +297,26 @@ defmodule Trenino.Firmware.UploadManager do
   end
 
   defp handle_upload_crash(upload, reason) do
-    # Release the port
     Connection.release_upload_access(upload.port, upload.release_token)
 
-    # Update history
     case Firmware.get_upload_history(upload.upload_id) do
       {:ok, history} -> Firmware.fail_upload(history, "Task crashed: #{inspect(reason)}", nil)
       _ -> :ok
     end
 
+    Sentry.capture_message("firmware_upload_crashed",
+      level: :error,
+      extra: %{
+        upload_id: upload.upload_id,
+        port: upload.port,
+        environment: upload.environment,
+        error_reason: :crash,
+        crash_reason: inspect(reason)
+      }
+    )
+
     broadcast({:upload_failed, upload.upload_id, :crash, "Upload task crashed unexpectedly"})
+    Logger.error("Upload task crashed: #{inspect(reason)}")
   end
 
   defp broadcast(event) do

--- a/lib/trenino/firmware/uploader.ex
+++ b/lib/trenino/firmware/uploader.ex
@@ -23,6 +23,10 @@ defmodule Trenino.Firmware.Uploader do
     "arduino" => [57_600, 115_200]
   }
 
+  @bootloader_initial_wait_ms 100
+  @bootloader_poll_interval_ms 300
+  @bootloader_poll_deadline_ms 5_000
+
   @doc """
   Returns alternate baud rates to try for a programmer when the initial
   baud rate fails. Filters out the already-tried baud rate.
@@ -210,30 +214,21 @@ defmodule Trenino.Firmware.Uploader do
   # Trigger bootloader on boards that need 1200bps touch (Leonardo, Micro, Pro Micro)
   defp maybe_trigger_bootloader(port, %{use_1200bps_touch: true}) do
     Logger.info("Triggering bootloader with 1200bps touch on #{port}")
-
-    # Get list of ports before triggering bootloader
     ports_before = get_available_ports()
 
     case Circuits.UART.start_link() do
       {:ok, uart} ->
-        # Open at 1200 baud, then close immediately to trigger bootloader
         result =
           case Circuits.UART.open(uart, port, speed: 1200) do
             :ok ->
-              # Small delay to ensure the signal is registered
-              Process.sleep(50)
+              Process.sleep(@bootloader_initial_wait_ms)
               Circuits.UART.close(uart)
-              # Wait for bootloader to start (typically appears on a new port)
               Logger.info("Waiting for bootloader to start...")
-              Process.sleep(1500)
-
-              # On Windows, the bootloader often appears on a different port
-              # Try to detect the new port
-              detect_bootloader_port(port, ports_before)
+              deadline = System.monotonic_time(:millisecond) + @bootloader_poll_deadline_ms
+              poll_for_bootloader_port(port, ports_before, deadline)
 
             {:error, reason} ->
               Logger.warning("Could not open port for 1200bps touch: #{inspect(reason)}")
-              # Continue anyway - device might already be in bootloader mode
               {:ok, port}
           end
 
@@ -242,68 +237,38 @@ defmodule Trenino.Firmware.Uploader do
 
       {:error, reason} ->
         Logger.warning("Could not start UART for 1200bps touch: #{inspect(reason)}")
-        # Continue anyway
         {:ok, port}
     end
   end
 
   defp maybe_trigger_bootloader(port, _config), do: {:ok, port}
 
-  # Detect the bootloader port after 1200bps touch
-  # On Windows, the device often reappears on a different COM port
-  defp detect_bootloader_port(original_port, ports_before) do
+  defp poll_for_bootloader_port(original_port, ports_before, deadline) do
     ports_after = get_available_ports()
     new_ports = ports_after -- ports_before
 
     cond do
-      # If the original port is still available, use it (common on macOS/Linux)
-      original_port in ports_after ->
-        Logger.info("Original port #{original_port} still available, using it")
-        {:ok, original_port}
-
-      # If a new port appeared, use that (common on Windows)
       length(new_ports) == 1 ->
         [new_port] = new_ports
         Logger.info("Bootloader appeared on new port #{new_port} (was #{original_port})")
         {:ok, new_port}
 
-      # Multiple new ports appeared - try to find one that looks like a bootloader
       length(new_ports) > 1 ->
-        # Prefer the highest numbered COM port (bootloader usually gets a new higher number)
         new_port = Enum.max(new_ports)
         Logger.info("Multiple new ports appeared, using #{new_port}")
         {:ok, new_port}
 
-      # No ports available - wait a bit more and retry once
-      true ->
-        Logger.info("Port disappeared, waiting for bootloader to appear...")
-        Process.sleep(1000)
-        retry_detect_bootloader_port(original_port, ports_before)
-    end
-  end
-
-  defp retry_detect_bootloader_port(original_port, ports_before) do
-    ports_after = get_available_ports()
-    new_ports = ports_after -- ports_before
-
-    cond do
       original_port in ports_after ->
+        Logger.info("Original port #{original_port} still available, using it")
         {:ok, original_port}
 
-      new_ports != [] ->
-        new_port = Enum.max(new_ports)
-        Logger.info("Bootloader appeared on port #{new_port}")
-        {:ok, new_port}
-
-      ports_after != [] ->
-        # Use any available port as a last resort
-        new_port = Enum.max(ports_after)
-        Logger.warning("Could not detect bootloader port, trying #{new_port}")
-        {:ok, new_port}
-
-      true ->
+      System.monotonic_time(:millisecond) >= deadline ->
         Logger.error("No ports available after bootloader trigger")
         {:error, :bootloader_port_not_found}
+
+      true ->
+        Process.sleep(@bootloader_poll_interval_ms)
+        poll_for_bootloader_port(original_port, ports_before, deadline)
     end
   end
 

--- a/lib/trenino/firmware/uploader.ex
+++ b/lib/trenino/firmware/uploader.ex
@@ -8,7 +8,7 @@ defmodule Trenino.Firmware.Uploader do
 
   require Logger
 
-  alias Trenino.Firmware.{Avrdude, DeviceRegistry}
+  alias Trenino.Firmware.{Avrdude, AvrdudeRunner, DeviceRegistry}
 
   @type progress_callback :: (integer(), String.t() -> any())
 
@@ -112,7 +112,7 @@ defmodule Trenino.Firmware.Uploader do
     args = build_args(config, port, hex_file_path)
     Logger.info("Running avrdude: #{avrdude_path} #{Enum.join(args, " ")}")
 
-    case run_avrdude(avrdude_path, args, callback) do
+    case AvrdudeRunner.run(avrdude_path, args, callback) do
       {:ok, output} ->
         {:ok, output}
 
@@ -346,67 +346,6 @@ defmodule Trenino.Firmware.Uploader do
       {:error, :hex_file_not_found, "Firmware file not found: #{path}"}
     end
   end
-
-  # Run avrdude and collect output
-  defp run_avrdude(avrdude_path, args, progress_callback) do
-    port =
-      Port.open({:spawn_executable, avrdude_path}, [
-        :binary,
-        :exit_status,
-        :stderr_to_stdout,
-        args: args
-      ])
-
-    collect_output(port, "", progress_callback)
-  end
-
-  defp collect_output(port, acc, progress_callback) do
-    receive do
-      {^port, {:data, data}} ->
-        new_acc = acc <> data
-
-        # Parse and report progress
-        if progress_callback do
-          parse_progress(data, progress_callback)
-        end
-
-        collect_output(port, new_acc, progress_callback)
-
-      {^port, {:exit_status, 0}} ->
-        {:ok, acc}
-
-      {^port, {:exit_status, _code}} ->
-        {:error, acc}
-    after
-      # 2 minute timeout
-      120_000 ->
-        Port.close(port)
-        {:error, acc <> "\n[Timeout: avrdude did not respond within 2 minutes]"}
-    end
-  end
-
-  # Parse avrdude output for progress updates
-  defp parse_progress(data, callback) do
-    # avrdude progress format: "Writing | ####... | 45% 1.15s"
-    # Also: "Reading | ####... | 100% 0.23s"
-    lines = String.split(data, "\n")
-
-    Enum.each(lines, fn line ->
-      case Regex.run(~r/(Reading|Writing|Verifying)\s+\|.*?\|\s+(\d+)%/, line) do
-        [_, operation, percent_str] ->
-          percent = String.to_integer(percent_str)
-          message = format_operation(operation, percent)
-          callback.(percent, message)
-
-        nil ->
-          :ok
-      end
-    end)
-  end
-
-  defp format_operation("Reading", _percent), do: "Reading device..."
-  defp format_operation("Writing", percent), do: "Writing flash (#{percent}%)"
-  defp format_operation("Verifying", percent), do: "Verifying (#{percent}%)"
 
   # Error patterns mapped to error atoms
   # Each pattern is either a string or a list of strings (all must match)

--- a/lib/trenino/serial/connection.ex
+++ b/lib/trenino/serial/connection.ex
@@ -25,6 +25,10 @@ defmodule Trenino.Serial.Connection do
   @cleanup_timeout_ms 5_000
   # Timeout for discovery operations (5 retries × 1s each + buffer)
   @discovery_timeout_ms 7_000
+  # Default GenServer.call timeout for blocking public API calls (ms).
+  # Overridable via Application env for tests.
+  @default_call_timeout_ms 5_000
+
   # Port name patterns to ignore (Bluetooth, debug consoles, etc.)
   @ignored_port_patterns [
     ~r/Bluetooth/i,
@@ -42,7 +46,7 @@ defmodule Trenino.Serial.Connection do
   @doc "Get all connected devices"
   @spec connected_devices() :: [DeviceConnection.t()]
   def connected_devices do
-    GenServer.call(__MODULE__, :connected_devices)
+    GenServer.call(__MODULE__, :connected_devices, call_timeout())
   catch
     :exit, _ -> []
   end
@@ -50,7 +54,7 @@ defmodule Trenino.Serial.Connection do
   @doc "Get all tracked devices (any status)"
   @spec list_devices() :: [DeviceConnection.t()]
   def list_devices do
-    GenServer.call(__MODULE__, :list_devices)
+    GenServer.call(__MODULE__, :list_devices, call_timeout())
   catch
     :exit, _ -> []
   end
@@ -66,6 +70,10 @@ defmodule Trenino.Serial.Connection do
 
   defp ignored_port?(port) do
     Enum.any?(@ignored_port_patterns, &Regex.match?(&1, port))
+  end
+
+  defp call_timeout do
+    Application.get_env(:trenino, :serial_connection_call_timeout_ms, @default_call_timeout_ms)
   end
 
   @doc "Trigger an immediate device scan"

--- a/lib/trenino_web/components/nav_components.ex
+++ b/lib/trenino_web/components/nav_components.ex
@@ -346,7 +346,7 @@ defmodule TreninoWeb.NavComponents do
       </div>
       <div :if={@device.status == :failed and flashable_error?(@device.error_type)} class="mt-2 pl-4">
         <.link
-          navigate={~p"/firmware?port=#{URI.encode_www_form(@device.port)}"}
+          navigate={~p"/firmware?port=#{@device.port}"}
           class="btn btn-xs btn-outline btn-primary"
         >
           <.icon name="hero-arrow-up-tray" class="w-3 h-3" /> Install Firmware

--- a/test/support/avrdude_fixtures.ex
+++ b/test/support/avrdude_fixtures.ex
@@ -1,0 +1,91 @@
+defmodule Trenino.AvrdudeFixtures do
+  @moduledoc """
+  Pre-recorded avrdude transcript strings for use in upload flow tests.
+  Each function returns the exact stdout+stderr output avrdude produces
+  for that scenario, matching the patterns in Uploader.@error_patterns.
+  """
+
+  @doc "Clean successful upload — avrdude exits 0."
+  def successful_upload do
+    """
+    avrdude: Version 7.1, compiled on Mar 10 2023 at 12:30:00
+
+    avrdude: AVR device initialized and ready to accept instructions
+    Reading | ################################################## | 100% 0.00s
+
+    avrdude: device signature = 0x1e9514 (probably m32u4)
+    avrdude: erasing chip
+    avrdude: reading input file "firmware.hex"
+    avrdude: writing flash (28672 bytes):
+
+    Writing | ################################################## | 100% 6.05s
+
+    avrdude: 28672 bytes of flash written
+    avrdude: verifying flash memory against firmware.hex:
+
+    Verifying | ################################################## | 100% 2.01s
+
+    avrdude: 28672 bytes of flash verified
+
+    avrdude done.  Thank you.
+    """
+  end
+
+  @doc "Old-bootloader Nano fails at 115200 baud — triggers baud-rate retry path."
+  def old_bootloader_nano_115200_fail do
+    """
+    avrdude: stk500_getsync() attempt 1 of 10: not in sync: resp=0x00
+    avrdude: stk500_getsync() attempt 2 of 10: not in sync: resp=0x00
+    avrdude: stk500_getsync() attempt 3 of 10: not in sync: resp=0x00
+    avrdude: stk500_recv(): programmer is not responding
+    avrdude: stk500_getsync(): not in sync: resp=0x00
+    """
+  end
+
+  @doc "Port not found — device unplugged or wrong COM port."
+  def port_not_found do
+    """
+    avrdude: ser_open(): can't open device "/dev/ttyUSB0": No such file or directory
+    """
+  end
+
+  @doc "Permission denied accessing serial port."
+  def permission_denied do
+    """
+    avrdude: ser_open(): permission denied accessing /dev/ttyUSB0
+    """
+  end
+
+  @doc "Wrong board selected — device signature does not match expected MCU."
+  def device_signature_mismatch do
+    """
+    avrdude: AVR device initialized and ready to accept instructions
+    Reading | ################################################## | 100% 0.00s
+
+    avrdude: device signature = 0x1e9514 (probably m32u4)
+    avrdude: Expected signature for ATmega328P is 1E 95 0F
+             Double check chip, or use -F to override this check.
+    """
+  end
+
+  @doc "Flash written but verify failed — unstable USB connection."
+  def verification_error do
+    """
+    avrdude: writing flash (28672 bytes):
+
+    Writing | ################################################## | 100% 6.05s
+
+    avrdude: verification error, first mismatch at byte 0x0100
+             0x3c != 0x1c
+    avrdude: verification error; content mismatch
+    """
+  end
+
+  @doc "Bootloader not responding — avr109 programmer on Micro/Leonardo."
+  def bootloader_not_responding do
+    """
+    avrdude: butterfly_recv(): programmer is not responding
+    avrdude: error: programmer did not respond to command: get sync
+    """
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -23,6 +23,7 @@ defmodule TreninoWeb.ConnCase do
       @endpoint TreninoWeb.Endpoint
 
       use TreninoWeb, :verified_routes
+      use Mimic
 
       # Import conveniences for testing with connections
       import Plug.Conn
@@ -33,6 +34,7 @@ defmodule TreninoWeb.ConnCase do
 
   setup tags do
     Trenino.DataCase.setup_sandbox(tags)
+    Trenino.DataCase.setup_forbidden_serial_stubs()
 
     unless tags[:consent_unset] do
       {:ok, _} = Trenino.Settings.set_error_reporting(:disabled)

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -27,11 +27,28 @@ defmodule Trenino.DataCase do
       import Ecto.Changeset
       import Ecto.Query
       import Trenino.DataCase
+
+      use Mimic
     end
   end
 
   setup tags do
     Trenino.DataCase.setup_sandbox(tags)
+    Trenino.DataCase.setup_forbidden_serial_stubs()
+    :ok
+  end
+
+  @doc """
+  Installs default Mimic stubs that forbid real serial / avrdude / discovery
+  access. Tests that legitimately need to simulate one of these subsystems
+  override the default with `Mimic.expect/3` or `Mimic.stub/3`.
+  """
+  def setup_forbidden_serial_stubs do
+    Mimic.set_mimic_private()
+    Mimic.stub_with(Circuits.UART, Trenino.Test.ForbiddenUART)
+    Mimic.stub_with(Trenino.Firmware.Avrdude, Trenino.Test.ForbiddenAvrdude)
+    Mimic.stub_with(Trenino.Firmware.AvrdudeRunner, Trenino.Test.ForbiddenAvrdudeRunner)
+    Mimic.stub_with(Trenino.Serial.Discovery, Trenino.Test.ForbiddenSerialDiscovery)
     :ok
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -88,7 +88,7 @@ defmodule Trenino.DataCase do
             "protocol" => "avr109",
             "mcu" => "atmega32u4",
             "speed" => 57_600,
-            "use1200bpsTouch" => true
+            "requires1200bpsTouch" => true
           }
         },
         %{
@@ -109,7 +109,7 @@ defmodule Trenino.DataCase do
             "protocol" => "avr109",
             "mcu" => "atmega32u4",
             "speed" => 57_600,
-            "use1200bpsTouch" => true
+            "requires1200bpsTouch" => true
           }
         },
         %{
@@ -120,7 +120,7 @@ defmodule Trenino.DataCase do
             "protocol" => "avr109",
             "mcu" => "atmega32u4",
             "speed" => 57_600,
-            "use1200bpsTouch" => true
+            "requires1200bpsTouch" => true
           }
         },
         %{

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -127,6 +127,17 @@ defmodule Trenino.DataCase do
   end
 
   @doc """
+  Captures Logger output during the given function. Use to wrap calls
+  in tests that intentionally exercise error/cleanup paths and would
+  otherwise leak [warning]/[error] lines into the test output.
+
+      silently(fn -> Connection.handle_decode_failure(garbage) end)
+  """
+  def silently(fun) when is_function(fun, 0) do
+    ExUnit.CaptureLog.capture_log(fun)
+  end
+
+  @doc """
   Loads basic device configurations into the DeviceRegistry for testing.
 
   This helper loads a minimal manifest with common Arduino devices to support

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -33,7 +33,12 @@ defmodule Trenino.DataCase do
   end
 
   setup tags do
-    Trenino.DataCase.setup_sandbox(tags)
+    if tags[:async] do
+      Trenino.DataCase.setup_isolated_repo()
+    else
+      Trenino.DataCase.setup_sandbox(tags)
+    end
+
     Trenino.DataCase.setup_forbidden_serial_stubs()
     :ok
   end
@@ -49,6 +54,51 @@ defmodule Trenino.DataCase do
     Mimic.stub_with(Trenino.Firmware.Avrdude, Trenino.Test.ForbiddenAvrdude)
     Mimic.stub_with(Trenino.Firmware.AvrdudeRunner, Trenino.Test.ForbiddenAvrdudeRunner)
     Mimic.stub_with(Trenino.Serial.Discovery, Trenino.Test.ForbiddenSerialDiscovery)
+    :ok
+  end
+
+  @doc """
+  For async tests: copies the pre-migrated template SQLite file to a
+  unique per-test path, starts a dynamic Trenino.Repo against it, and
+  routes the test process's queries via put_dynamic_repo/1. On test
+  exit, restores the default repo and removes the temp file.
+
+  Each test gets its own SQLite file, eliminating writer-lock contention
+  between async tests.
+  """
+  def setup_isolated_repo do
+    template_path = Application.fetch_env!(:trenino, :test_template_db_path)
+    test_id = :erlang.unique_integer([:positive])
+    test_db_path = Path.join(Path.dirname(template_path), "isolated_test_#{test_id}.db")
+    File.cp!(template_path, test_db_path)
+
+    {:ok, repo_pid} =
+      Trenino.Repo.start_link(
+        name: nil,
+        database: test_db_path,
+        pool: DBConnection.ConnectionPool,
+        pool_size: 1,
+        journal_mode: :wal,
+        synchronous: :normal,
+        busy_timeout: 1_000
+      )
+
+    Trenino.Repo.put_dynamic_repo(repo_pid)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      Trenino.Repo.put_dynamic_repo(Trenino.Repo)
+
+      try do
+        :ok = GenServer.stop(repo_pid)
+      catch
+        :exit, _ -> :ok
+      end
+
+      File.rm(test_db_path)
+      File.rm(test_db_path <> "-wal")
+      File.rm(test_db_path <> "-shm")
+    end)
+
     :ok
   end
 

--- a/test/support/forbidden_serial.ex
+++ b/test/support/forbidden_serial.ex
@@ -1,0 +1,120 @@
+defmodule Trenino.Test.ForbiddenUART do
+  @moduledoc """
+  Default Mimic stub for Circuits.UART. Every function raises with a clear
+  message so tests that forget to stub real serial access fail loudly instead
+  of touching real hardware.
+  """
+
+  def open(_pid, _port), do: forbid("Circuits.UART.open/2")
+  def open(_pid, _port, _opts), do: forbid("Circuits.UART.open/3")
+  def close(_pid), do: forbid("Circuits.UART.close/1")
+  def write(_pid, _data), do: forbid("Circuits.UART.write/2")
+  def write(_pid, _data, _opts), do: forbid("Circuits.UART.write/3")
+  def read(_pid), do: forbid("Circuits.UART.read/1")
+  def read(_pid, _timeout), do: forbid("Circuits.UART.read/2")
+  def enumerate, do: forbid("Circuits.UART.enumerate/0")
+  def start_link, do: forbid("Circuits.UART.start_link/0")
+  def start_link(_opts), do: forbid("Circuits.UART.start_link/1")
+  def stop(_pid), do: forbid("Circuits.UART.stop/1")
+  def controlling_process(_pid, _new_owner), do: forbid("Circuits.UART.controlling_process/2")
+  def configure(_pid, _opts), do: forbid("Circuits.UART.configure/2")
+  def configuration(_pid), do: forbid("Circuits.UART.configuration/1")
+  def flush(_pid), do: forbid("Circuits.UART.flush/1")
+  def flush(_pid, _direction), do: forbid("Circuits.UART.flush/2")
+  def drain(_pid), do: forbid("Circuits.UART.drain/1")
+  def send_break(_pid), do: forbid("Circuits.UART.send_break/1")
+  def send_break(_pid, _duration), do: forbid("Circuits.UART.send_break/2")
+  def set_break(_pid, _level), do: forbid("Circuits.UART.set_break/2")
+  def set_dtr(_pid, _level), do: forbid("Circuits.UART.set_dtr/2")
+  def set_rts(_pid, _level), do: forbid("Circuits.UART.set_rts/2")
+  def signals(_pid), do: forbid("Circuits.UART.signals/1")
+  def find_pids, do: forbid("Circuits.UART.find_pids/0")
+
+  # OTP callbacks exported by Circuits.UART (it is itself a GenServer).
+  # Required here because Mimic.stub_with verifies the stub module declares
+  # every export of the real module — they are never invoked directly by tests.
+  def child_spec(_arg), do: forbid("Circuits.UART.child_spec/1")
+  def init(_arg), do: forbid("Circuits.UART.init/1")
+  def handle_call(_request, _from, _state), do: forbid("Circuits.UART.handle_call/3")
+  def handle_cast(_request, _state), do: forbid("Circuits.UART.handle_cast/2")
+  def handle_info(_message, _state), do: forbid("Circuits.UART.handle_info/2")
+  def code_change(_old_vsn, _state, _extra), do: forbid("Circuits.UART.code_change/3")
+  def terminate(_reason, _state), do: forbid("Circuits.UART.terminate/2")
+
+  defp forbid(call) do
+    raise """
+    Real #{call} was called from a test.
+
+    Tests must not touch real serial hardware. Stub explicitly with Mimic:
+
+        expect(Circuits.UART, :open, fn _pid, _port, _opts -> :ok end)
+
+    Or use a higher-level helper from Trenino.SerialTestHelpers.
+    """
+  end
+end
+
+defmodule Trenino.Test.ForbiddenAvrdude do
+  @moduledoc """
+  Default Mimic stub for Trenino.Firmware.Avrdude.
+  Raises on any call so tests that forget to stub avrdude fail loudly
+  instead of spawning real subprocesses.
+  """
+
+  def executable_path, do: forbid("Avrdude.executable_path/0")
+  def executable_path!, do: forbid("Avrdude.executable_path!/0")
+  def available?, do: forbid("Avrdude.available?/0")
+  def version, do: forbid("Avrdude.version/0")
+  def conf_path, do: forbid("Avrdude.conf_path/0")
+
+  defp forbid(call) do
+    raise """
+    Real #{call} was called from a test.
+
+    Tests must not spawn real avrdude subprocesses. Stub explicitly:
+
+        expect(Trenino.Firmware.Avrdude, :available?, fn -> true end)
+    """
+  end
+end
+
+defmodule Trenino.Test.ForbiddenAvrdudeRunner do
+  @moduledoc """
+  Default Mimic stub for Trenino.Firmware.AvrdudeRunner.
+  Raises on any call so tests that forget to stub avrdude fail loudly
+  instead of spawning real subprocesses.
+  """
+
+  def run(_avrdude_path, _args, _progress_callback),
+    do: forbid("AvrdudeRunner.run/3")
+
+  defp forbid(call) do
+    raise """
+    Real #{call} was called from a test.
+
+    Tests must not spawn real avrdude subprocesses. Stub explicitly:
+
+        expect(Trenino.Firmware.AvrdudeRunner, :run, fn _, _, _ -> {:ok, "ok output"} end)
+    """
+  end
+end
+
+defmodule Trenino.Test.ForbiddenSerialDiscovery do
+  @moduledoc """
+  Default Mimic stub for Trenino.Serial.Discovery. Raises on any call.
+  """
+
+  def discover(_uart_pid), do: forbid("Trenino.Serial.Discovery.discover/1")
+
+  defp forbid(call) do
+    raise """
+    Real #{call} was called from a test.
+
+    Tests must not perform real device discovery. Stub explicitly:
+
+        expect(Trenino.Serial.Discovery, :discover, fn _pid ->
+          {:ok, %Trenino.Serial.Protocol.IdentityResponse{...}}
+        end)
+    """
+  end
+end

--- a/test/support/pubsub_helpers.ex
+++ b/test/support/pubsub_helpers.ex
@@ -1,0 +1,49 @@
+defmodule Trenino.PubSubHelpers do
+  @moduledoc """
+  Test-only helpers for synchronizing on Phoenix.PubSub state.
+
+  Replaces `Process.sleep/1`-based race patterns where a test broadcasts
+  to a topic and assumes a freshly-spawned subscriber is ready in time.
+  """
+
+  @registry Trenino.PubSub
+
+  @doc """
+  Block until at least one process is subscribed to `topic`, or the timeout
+  expires.
+
+  Returns `:ok` on success or `{:error, :timeout}`.
+
+  ## Example
+
+      task = Task.async(fn -> SomeGenServer.subscribe_and_wait() end)
+      :ok = wait_for_subscriber("hardware:input_values:test_port")
+      Phoenix.PubSub.broadcast(Trenino.PubSub, "hardware:input_values:test_port", :event)
+      assert {:ok, _} = Task.await(task, 1_000)
+  """
+  @spec wait_for_subscriber(String.t(), pos_integer()) :: :ok | {:error, :timeout}
+  def wait_for_subscriber(topic, timeout_ms \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait(topic, deadline)
+  end
+
+  defp do_wait(topic, deadline) do
+    if has_subscriber?(topic) do
+      :ok
+    else
+      if System.monotonic_time(:millisecond) > deadline do
+        {:error, :timeout}
+      else
+        Process.sleep(5)
+        do_wait(topic, deadline)
+      end
+    end
+  end
+
+  defp has_subscriber?(topic) do
+    case Registry.lookup(@registry, topic) do
+      [] -> false
+      [_ | _] -> true
+    end
+  end
+end

--- a/test/support/serial_safety_case.ex
+++ b/test/support/serial_safety_case.ex
@@ -1,0 +1,25 @@
+defmodule Trenino.SerialSafetyCase do
+  @moduledoc """
+  Test case template for plain ExUnit.Case files that exercise serial /
+  avrdude / discovery code paths but do not need the database sandbox.
+
+  Installs the same forbidden default Mimic stubs as DataCase so accidental
+  hardware access raises loudly.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using opts do
+    async = Keyword.get(opts, :async, true)
+
+    quote do
+      use ExUnit.Case, async: unquote(async)
+      use Mimic
+    end
+  end
+
+  setup do
+    Trenino.DataCase.setup_forbidden_serial_stubs()
+    :ok
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -47,6 +47,6 @@ Trenino.Repo.put_dynamic_repo(Trenino.Repo)
 # Make the path available at runtime to DataCase
 Application.put_env(:trenino, :test_template_db_path, template_path)
 
-ExUnit.start()
+ExUnit.start(capture_log: true)
 ExUnit.configure(exclude: [:skip_without_avrdude])
 Ecto.Adapters.SQL.Sandbox.mode(Trenino.Repo, :manual)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,4 +16,5 @@ Mimic.copy(Trenino.Firmware.Avrdude)
 Mimic.copy(Trenino.Firmware.AvrdudeRunner)
 
 ExUnit.start()
+ExUnit.configure(exclude: [:skip_without_avrdude])
 Ecto.Adapters.SQL.Sandbox.mode(Trenino.Repo, :manual)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,6 +16,37 @@ Mimic.copy(Trenino.Firmware.Avrdude)
 Mimic.copy(Trenino.Firmware.AvrdudeRunner)
 Mimic.copy(Trenino.Serial.Connection)
 
+# Build a pre-migrated template SQLite file once. Async DataCase tests
+# copy it to get an isolated per-test DB without paying the migration cost.
+template_path = Path.expand("../tmp/test_template.db", __DIR__)
+File.mkdir_p!(Path.dirname(template_path))
+File.rm(template_path)
+
+{:ok, template_pid} =
+  Trenino.Repo.start_link(
+    name: nil,
+    database: template_path,
+    pool: DBConnection.ConnectionPool,
+    pool_size: 1,
+    journal_mode: :wal,
+    synchronous: :normal
+  )
+
+Trenino.Repo.put_dynamic_repo(template_pid)
+
+migrations_path = Application.app_dir(:trenino, "priv/repo/migrations")
+
+Ecto.Migrator.run(Trenino.Repo, migrations_path, :up,
+  all: true,
+  dynamic_repo: template_pid
+)
+
+Trenino.Repo.put_dynamic_repo(Trenino.Repo)
+:ok = GenServer.stop(template_pid)
+
+# Make the path available at runtime to DataCase
+Application.put_env(:trenino, :test_template_db_path, template_path)
+
 ExUnit.start()
 ExUnit.configure(exclude: [:skip_without_avrdude])
 Ecto.Adapters.SQL.Sandbox.mode(Trenino.Repo, :manual)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -12,6 +12,8 @@ Mimic.copy(Trenino.Simulator.ControlDetectionSession)
 Mimic.copy(Trenino.AppVersion)
 Mimic.copy(Circuits.UART, type_check: true)
 Mimic.copy(Trenino.Serial.Discovery, type_check: true)
+Mimic.copy(Trenino.Firmware.Avrdude)
+Mimic.copy(Trenino.Firmware.AvrdudeRunner)
 
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Trenino.Repo, :manual)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -14,6 +14,7 @@ Mimic.copy(Circuits.UART, type_check: true)
 Mimic.copy(Trenino.Serial.Discovery, type_check: true)
 Mimic.copy(Trenino.Firmware.Avrdude)
 Mimic.copy(Trenino.Firmware.AvrdudeRunner)
+Mimic.copy(Trenino.Serial.Connection)
 
 ExUnit.start()
 ExUnit.configure(exclude: [:skip_without_avrdude])

--- a/test/trenino/firmware/device_registry_test.exs
+++ b/test/trenino/firmware/device_registry_test.exs
@@ -166,7 +166,7 @@ defmodule Trenino.Firmware.DeviceRegistryTest do
     test "returns all devices from loaded manifest" do
       devices = DeviceRegistry.list_available_devices()
 
-      assert length(devices) == 7
+      assert length(devices) == 6
 
       environments = Enum.map(devices, & &1.environment) |> Enum.sort()
 
@@ -176,7 +176,6 @@ defmodule Trenino.Firmware.DeviceRegistryTest do
       assert "micro" in environments
       assert "sparkfun_promicro16" in environments
       assert "megaatmega2560" in environments
-      assert "due" in environments
     end
 
     test "devices are sorted by display name" do
@@ -205,7 +204,7 @@ defmodule Trenino.Firmware.DeviceRegistryTest do
     test "returns options suitable for form select" do
       options = DeviceRegistry.select_options()
 
-      assert length(options) == 7
+      assert length(options) == 6
 
       for {name, env} <- options do
         assert is_binary(name)
@@ -342,7 +341,7 @@ defmodule Trenino.Firmware.DeviceRegistryTest do
       assert config.display_name == "Custom Leonardo"
     end
 
-    test "loads all devices with valid uploadConfig from manifest" do
+    test "accepts devices with supported avrdude protocols" do
       manifest = %{
         "version" => "1.0",
         "project" => "trenino_firmware",
@@ -372,17 +371,12 @@ defmodule Trenino.Firmware.DeviceRegistryTest do
 
       assert :ok = DeviceRegistry.reload_from_manifest(manifest, 1)
 
-      # Should have uno
       assert {:ok, uno_config} = DeviceRegistry.get_device_config("uno")
-      assert uno_config.environment == "uno"
       assert uno_config.programmer == "arduino"
 
-      # Should also have custom board (any protocol/mcu is accepted from manifest)
-      assert {:ok, custom_config} = DeviceRegistry.get_device_config("custom_board")
-      assert custom_config.environment == "custom_board"
-      assert custom_config.programmer == "custom_protocol"
-      assert custom_config.mcu == "custom_mcu"
-      assert custom_config.baud_rate == 9600
+      assert {:error, :unknown_device} = DeviceRegistry.get_device_config("custom_board")
+
+      assert length(DeviceRegistry.list_available_devices()) == 1
     end
 
     test "returns error when manifest has no devices" do
@@ -416,6 +410,53 @@ defmodule Trenino.Firmware.DeviceRegistryTest do
       # Registry should be empty (no valid devices)
       devices = DeviceRegistry.list_available_devices()
       assert devices == []
+    end
+
+    test "rejects devices whose upload protocol is not in the avrdude allowlist" do
+      manifest = %{
+        "version" => "1.0",
+        "project" => "trenino_firmware",
+        "devices" => [
+          %{
+            "environment" => "uno",
+            "displayName" => "Arduino Uno",
+            "firmwareFile" => "trenino-uno.hex",
+            "uploadConfig" => %{
+              "protocol" => "arduino",
+              "mcu" => "atmega328p",
+              "speed" => 115_200
+            }
+          },
+          %{
+            "environment" => "due",
+            "displayName" => "Arduino Due",
+            "firmwareFile" => "trenino-due.bin",
+            "uploadConfig" => %{
+              "protocol" => "sam-ba",
+              "mcu" => "at91sam3x8e",
+              "speed" => 115_200
+            }
+          },
+          %{
+            "environment" => "esp32_device",
+            "displayName" => "ESP32",
+            "firmwareFile" => "trenino-esp32.bin",
+            "uploadConfig" => %{
+              "protocol" => "esptool",
+              "mcu" => "esp32",
+              "speed" => 115_200
+            }
+          }
+        ]
+      }
+
+      assert :ok = DeviceRegistry.reload_from_manifest(manifest, 1)
+
+      assert {:ok, _} = DeviceRegistry.get_device_config("uno")
+      assert {:error, :unknown_device} = DeviceRegistry.get_device_config("due")
+      assert {:error, :unknown_device} = DeviceRegistry.get_device_config("esp32_device")
+
+      assert length(DeviceRegistry.list_available_devices()) == 1
     end
 
     test "merges manifest devices with hardware configs" do
@@ -500,7 +541,7 @@ defmodule Trenino.Firmware.DeviceRegistryTest do
 
       # Should still have fallback devices available
       devices = DeviceRegistry.list_available_devices()
-      assert length(devices) == 7
+      assert length(devices) == 6
     end
   end
 end

--- a/test/trenino/firmware/device_registry_test.exs
+++ b/test/trenino/firmware/device_registry_test.exs
@@ -1,6 +1,8 @@
 defmodule Trenino.Firmware.DeviceRegistryTest do
   use Trenino.DataCase, async: false
 
+  import ExUnit.CaptureLog
+
   alias Trenino.Firmware
   alias Trenino.Firmware.DeviceRegistry
 
@@ -98,14 +100,14 @@ defmodule Trenino.Firmware.DeviceRegistryTest do
 
     # After each test, clear the manifest
     on_exit(fn ->
-      # Reload with empty manifest to clear devices
+      # Reload with empty manifest to clear devices — suppress expected warning/error logs
       manifest = %{
         "version" => "1.0",
         "project" => "trenino_firmware",
         "devices" => []
       }
 
-      DeviceRegistry.reload_from_manifest(manifest, 0)
+      capture_log(fn -> DeviceRegistry.reload_from_manifest(manifest, 0) end)
     end)
 
     :ok
@@ -386,7 +388,12 @@ defmodule Trenino.Firmware.DeviceRegistryTest do
         "devices" => []
       }
 
-      assert {:error, :no_devices} = DeviceRegistry.reload_from_manifest(manifest, 1)
+      log =
+        capture_log(fn ->
+          assert {:error, :no_devices} = DeviceRegistry.reload_from_manifest(manifest, 1)
+        end)
+
+      assert log =~ "Manifest contains no devices"
 
       # Registry should be empty (no devices available)
       devices = DeviceRegistry.list_available_devices()
@@ -405,7 +412,12 @@ defmodule Trenino.Firmware.DeviceRegistryTest do
         ]
       }
 
-      assert {:error, :no_valid_devices} = DeviceRegistry.reload_from_manifest(manifest, 1)
+      log =
+        capture_log(fn ->
+          assert {:error, :no_valid_devices} = DeviceRegistry.reload_from_manifest(manifest, 1)
+        end)
+
+      assert log =~ "No valid devices in manifest"
 
       # Registry should be empty (no valid devices)
       devices = DeviceRegistry.list_available_devices()

--- a/test/trenino/firmware/downloader_test.exs
+++ b/test/trenino/firmware/downloader_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Firmware.DownloaderTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   import ExUnit.CaptureLog
 

--- a/test/trenino/firmware/downloader_test.exs
+++ b/test/trenino/firmware/downloader_test.exs
@@ -1,6 +1,5 @@
 defmodule Trenino.Firmware.DownloaderTest do
   use Trenino.DataCase, async: false
-  use Mimic
 
   import ExUnit.CaptureLog
 

--- a/test/trenino/firmware/firmware_file_test.exs
+++ b/test/trenino/firmware/firmware_file_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Firmware.FirmwareFileTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Firmware.FilePath
   alias Trenino.Firmware.FirmwareFile

--- a/test/trenino/firmware/firmware_release_test.exs
+++ b/test/trenino/firmware/firmware_release_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Firmware.FirmwareReleaseTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Firmware.FirmwareFile
   alias Trenino.Firmware.FirmwareRelease

--- a/test/trenino/firmware/release_manifest_integration_test.exs
+++ b/test/trenino/firmware/release_manifest_integration_test.exs
@@ -7,7 +7,7 @@ defmodule Trenino.Firmware.ReleaseManifestIntegrationTest do
   release.json format from the trenino_firmware repository.
   """
 
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Firmware
   alias Trenino.Firmware.DeviceRegistry

--- a/test/trenino/firmware/release_manifest_integration_test.exs
+++ b/test/trenino/firmware/release_manifest_integration_test.exs
@@ -124,19 +124,18 @@ defmodule Trenino.Firmware.ReleaseManifestIntegrationTest do
       # Step 3: Reload device registry from manifest
       assert :ok = DeviceRegistry.reload_from_manifest(@test_manifest, release.id)
 
-      # Step 4: Verify all devices are available
+      # Step 4: Verify all supported devices are available
+      # "due" (sam-ba) and "esp32dev" (esptool) are silently rejected
       devices = DeviceRegistry.list_available_devices()
-      assert length(devices) == 6
+      assert length(devices) == 4
 
-      # Verify device names
+      # Verify device names (sam-ba and esptool devices are excluded)
       device_names = Enum.map(devices, & &1.display_name) |> Enum.sort()
 
       expected_names = [
-        "Arduino Due",
         "Arduino Leonardo",
         "Arduino Nano",
         "Arduino Uno",
-        "ESP32 DevKit",
         "SparkFun Pro Micro"
       ]
 
@@ -163,12 +162,8 @@ defmodule Trenino.Firmware.ReleaseManifestIntegrationTest do
       assert leo_config.baud_rate == 57_600
       assert leo_config.use_1200bps_touch == true
 
-      # Test ESP32 configuration (different protocol)
-      {:ok, esp_config} = DeviceRegistry.get_device_config("esp32dev")
-      assert esp_config.programmer == "esptool"
-      assert esp_config.mcu == "esp32"
-      assert esp_config.baud_rate == 921_600
-      assert esp_config.use_1200bps_touch == false
+      # esp32dev (esptool protocol) is silently rejected at load time
+      assert {:error, :unknown_device} = DeviceRegistry.get_device_config("esp32dev")
     end
 
     test "firmware file selection works with environment strings" do
@@ -204,10 +199,11 @@ defmodule Trenino.Firmware.ReleaseManifestIntegrationTest do
 
       options = DeviceRegistry.select_options()
 
-      assert length(options) == 6
+      # Only 4 devices: sam-ba (due) and esptool (esp32dev) are silently rejected
+      assert length(options) == 4
       assert {"Arduino Nano", "nanoatmega328new"} in options
       assert {"Arduino Leonardo", "leonardo"} in options
-      assert {"ESP32 DevKit", "esp32dev"} in options
+      refute {"ESP32 DevKit", "esp32dev"} in options
     end
 
     test "detects devices from firmware filenames" do
@@ -235,8 +231,8 @@ defmodule Trenino.Firmware.ReleaseManifestIntegrationTest do
       {:ok, leo} = DeviceRegistry.get_device_config("leonardo")
       assert leo.mcu == "m32u4", "atmega32u4 should be normalized to m32u4"
 
-      {:ok, due} = DeviceRegistry.get_device_config("due")
-      assert due.mcu == "at91sam3x8e", "ARM MCU should keep full name"
+      # "due" uses sam-ba protocol which is not supported, so it is silently rejected
+      assert {:error, :unknown_device} = DeviceRegistry.get_device_config("due")
     end
 
     test "handles missing uploadConfig gracefully" do

--- a/test/trenino/firmware/update_checker_test.exs
+++ b/test/trenino/firmware/update_checker_test.exs
@@ -1,6 +1,5 @@
 defmodule Trenino.Firmware.UpdateCheckerTest do
   use Trenino.DataCase, async: false
-  use Mimic
 
   alias Trenino.Firmware
   alias Trenino.Firmware.UpdateCheck

--- a/test/trenino/firmware/update_checker_test.exs
+++ b/test/trenino/firmware/update_checker_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Firmware.UpdateCheckerTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Firmware
   alias Trenino.Firmware.UpdateCheck

--- a/test/trenino/firmware/upload_flow_test.exs
+++ b/test/trenino/firmware/upload_flow_test.exs
@@ -1,8 +1,6 @@
 defmodule Trenino.Firmware.UploadFlowTest do
   use Trenino.DataCase, async: false
 
-  import Mimic
-
   alias Trenino.AvrdudeFixtures
   alias Trenino.Firmware.Avrdude
   alias Trenino.Firmware.AvrdudeRunner
@@ -18,6 +16,7 @@ defmodule Trenino.Firmware.UploadFlowTest do
     on_exit(fn -> File.rm(hex_file) end)
 
     stub(Avrdude, :executable_path, fn -> {:ok, "/fake/avrdude"} end)
+    stub(Avrdude, :conf_path, fn -> {:error, :not_found} end)
 
     {:ok, hex_file: hex_file}
   end

--- a/test/trenino/firmware/upload_flow_test.exs
+++ b/test/trenino/firmware/upload_flow_test.exs
@@ -1,0 +1,107 @@
+defmodule Trenino.Firmware.UploadFlowTest do
+  use Trenino.DataCase, async: false
+
+  import Mimic
+
+  alias Trenino.AvrdudeFixtures
+  alias Trenino.Firmware.Avrdude
+  alias Trenino.Firmware.AvrdudeRunner
+  alias Trenino.Firmware.Uploader
+
+  setup do
+    load_test_devices()
+
+    hex_file =
+      Path.join(System.tmp_dir!(), "test_firmware_#{System.unique_integer([:positive])}.hex")
+
+    File.write!(hex_file, ":00000001FF\n")
+    on_exit(fn -> File.rm(hex_file) end)
+
+    stub(Avrdude, :executable_path, fn -> {:ok, "/fake/avrdude"} end)
+
+    {:ok, hex_file: hex_file}
+  end
+
+  describe "successful upload" do
+    test "returns ok with duration and output", %{hex_file: hex_file} do
+      stub(AvrdudeRunner, :run, fn _path, _args, _cb ->
+        {:ok, AvrdudeFixtures.successful_upload()}
+      end)
+
+      assert {:ok, %{duration_ms: duration, output: output}} =
+               Uploader.upload("COM3", "uno", hex_file)
+
+      assert is_integer(duration) and duration >= 0
+      assert output =~ "avrdude done"
+    end
+  end
+
+  describe "non-retrying errors" do
+    test "returns :wrong_board_type immediately on device signature mismatch", %{
+      hex_file: hex_file
+    } do
+      stub(AvrdudeRunner, :run, fn _path, _args, _cb ->
+        {:error, AvrdudeFixtures.device_signature_mismatch()}
+      end)
+
+      assert {:error, :wrong_board_type, output} = Uploader.upload("COM3", "uno", hex_file)
+      assert output =~ "device signature"
+    end
+
+    test "returns :permission_denied immediately without retry", %{hex_file: hex_file} do
+      stub(AvrdudeRunner, :run, fn _path, _args, _cb ->
+        {:error, AvrdudeFixtures.permission_denied()}
+      end)
+
+      assert {:error, :permission_denied, _output} = Uploader.upload("COM3", "uno", hex_file)
+    end
+
+    test "returns :verification_failed immediately without retry", %{hex_file: hex_file} do
+      stub(AvrdudeRunner, :run, fn _path, _args, _cb ->
+        {:error, AvrdudeFixtures.verification_error()}
+      end)
+
+      assert {:error, :verification_failed, _output} = Uploader.upload("COM3", "uno", hex_file)
+    end
+
+    test "returns :hex_file_not_found when hex file does not exist" do
+      assert {:error, :hex_file_not_found, message} =
+               Uploader.upload("COM3", "uno", "/nonexistent/firmware.hex")
+
+      assert message =~ "not found"
+    end
+
+    test "returns :unknown_device for unrecognised environment", %{hex_file: hex_file} do
+      assert {:error, :unknown_device, message} =
+               Uploader.upload("COM3", "totally_unknown_board", hex_file)
+
+      assert message =~ "Unknown device environment"
+    end
+  end
+
+  describe "baud-rate retry (old-bootloader Nano)" do
+    test "retries at 57600 when 115200 fails with not-in-sync", %{hex_file: hex_file} do
+      stub(AvrdudeRunner, :run, fn _path, args, _cb ->
+        baud = Enum.at(args, Enum.find_index(args, &(&1 == "-b")) + 1)
+
+        if baud == "115200" do
+          {:error, AvrdudeFixtures.old_bootloader_nano_115200_fail()}
+        else
+          {:ok, AvrdudeFixtures.successful_upload()}
+        end
+      end)
+
+      assert {:ok, %{duration_ms: _, output: _}} =
+               Uploader.upload("COM3", "nanoatmega328", hex_file)
+    end
+
+    test "returns :bootloader_not_responding when all baud rates fail", %{hex_file: hex_file} do
+      stub(AvrdudeRunner, :run, fn _path, _args, _cb ->
+        {:error, AvrdudeFixtures.old_bootloader_nano_115200_fail()}
+      end)
+
+      assert {:error, :bootloader_not_responding, _} =
+               Uploader.upload("COM3", "nanoatmega328", hex_file)
+    end
+  end
+end

--- a/test/trenino/firmware/upload_flow_test.exs
+++ b/test/trenino/firmware/upload_flow_test.exs
@@ -104,4 +104,47 @@ defmodule Trenino.Firmware.UploadFlowTest do
                Uploader.upload("COM3", "nanoatmega328", hex_file)
     end
   end
+
+  describe "1200bps touch + bootloader port polling" do
+    test "succeeds when bootloader COM port takes three polls to appear (Windows scenario)", %{
+      hex_file: hex_file
+    } do
+      # Simulate Windows COM port enumeration sequence:
+      # call 0 — before touch: COM5 present
+      # call 1 — first poll after touch: port disappeared
+      # call 2 — second poll: still gone
+      # call 3+ — third poll: bootloader appeared on COM6
+      # The old code (single retry) fails at call 2; the polling loop succeeds at call 3.
+      {:ok, mock_uart} = Agent.start_link(fn -> :ok end)
+      {:ok, enum_agent} = Agent.start_link(fn -> 0 end)
+
+      on_exit(fn ->
+        if Process.alive?(mock_uart), do: Agent.stop(mock_uart)
+        if Process.alive?(enum_agent), do: Agent.stop(enum_agent)
+      end)
+
+      stub(Circuits.UART, :start_link, fn -> {:ok, mock_uart} end)
+      stub(Circuits.UART, :open, fn ^mock_uart, "COM5", [speed: 1200] -> :ok end)
+      stub(Circuits.UART, :close, fn ^mock_uart -> :ok end)
+
+      stub(Circuits.UART, :enumerate, fn ->
+        call_n = Agent.get_and_update(enum_agent, fn n -> {n, n + 1} end)
+
+        case call_n do
+          0 -> %{"COM5" => %{}}
+          1 -> %{}
+          2 -> %{}
+          _ -> %{"COM5" => %{}, "COM6" => %{}}
+        end
+      end)
+
+      stub(AvrdudeRunner, :run, fn _path, args, _cb ->
+        assert "COM6" in args
+        {:ok, AvrdudeFixtures.successful_upload()}
+      end)
+
+      assert {:ok, %{duration_ms: _, output: _}} =
+               Uploader.upload("COM5", "micro", hex_file)
+    end
+  end
 end

--- a/test/trenino/firmware/upload_history_test.exs
+++ b/test/trenino/firmware/upload_history_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Firmware.UploadHistoryTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Firmware.FirmwareFile
   alias Trenino.Firmware.FirmwareRelease

--- a/test/trenino/firmware/uploader_test.exs
+++ b/test/trenino/firmware/uploader_test.exs
@@ -7,6 +7,8 @@ defmodule Trenino.Firmware.UploaderTest do
   setup do
     # Load test device configurations for uploader tests
     load_test_devices()
+    stub(Trenino.Firmware.Avrdude, :executable_path, fn -> {:ok, "/fake/avrdude"} end)
+    stub(Trenino.Firmware.Avrdude, :conf_path, fn -> {:error, :not_found} end)
     :ok
   end
 

--- a/test/trenino/firmware/uploader_test.exs
+++ b/test/trenino/firmware/uploader_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Firmware.UploaderTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Firmware.Avrdude
   alias Trenino.Firmware.Uploader

--- a/test/trenino/firmware_test.exs
+++ b/test/trenino/firmware_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.FirmwareTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Firmware
   alias Trenino.Firmware.FilePath

--- a/test/trenino/hardware/bldc_profile_builder_test.exs
+++ b/test/trenino/hardware/bldc_profile_builder_test.exs
@@ -1,7 +1,7 @@
 defmodule Trenino.Hardware.BLDCProfileBuilderTest do
   @moduledoc false
 
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Hardware.BLDCProfileBuilder
   alias Trenino.Serial.Protocol.LoadBLDCProfile

--- a/test/trenino/hardware/input_test.exs
+++ b/test/trenino/hardware/input_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Hardware.InputTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Hardware.Input
 

--- a/test/trenino/hardware/output_test.exs
+++ b/test/trenino/hardware/output_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Hardware.OutputTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Hardware
   alias Trenino.Hardware.Output

--- a/test/trenino/hardware_test.exs
+++ b/test/trenino/hardware_test.exs
@@ -1,6 +1,6 @@
 defmodule Trenino.HardwareTest do
   # async: false due to SQLite write lock contention with other tests
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Hardware
   alias Trenino.Hardware.Device

--- a/test/trenino/integration/bldc_lever_flow_test.exs
+++ b/test/trenino/integration/bldc_lever_flow_test.exs
@@ -554,8 +554,8 @@ defmodule Trenino.Integration.BLDCLeverFlowTest do
       assert_receive {:profile_loaded, profile}, 500
       assert length(profile.detents) == 1
 
-      # Give time for any additional messages
-      Process.sleep(100)
+      # Confirm no additional profiles arrive
+      refute_receive {:profile_loaded, _}, 50
 
       # Verify only one profile was sent
       assert :counters.get(profile_count, 1) == 1

--- a/test/trenino/integration/bldc_lever_flow_test.exs
+++ b/test/trenino/integration/bldc_lever_flow_test.exs
@@ -13,7 +13,6 @@ defmodule Trenino.Integration.BLDCLeverFlowTest do
   """
 
   use Trenino.DataCase, async: false
-  use Mimic
 
   alias Trenino.Hardware
   alias Trenino.Serial.Connection, as: SerialConnection

--- a/test/trenino/mcp/server_test.exs
+++ b/test/trenino/mcp/server_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.MCP.ServerTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.MCP.Server
 

--- a/test/trenino/mcp/tool_registry_test.exs
+++ b/test/trenino/mcp/tool_registry_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.MCP.ToolRegistryTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.MCP.ToolRegistry
 

--- a/test/trenino/mcp/tools/button_binding_tools_test.exs
+++ b/test/trenino/mcp/tools/button_binding_tools_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.MCP.Tools.ButtonBindingToolsTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Hardware
   alias Trenino.MCP.Tools.ButtonBindingTools

--- a/test/trenino/mcp/tools/detection_tools_test.exs
+++ b/test/trenino/mcp/tools/detection_tools_test.exs
@@ -4,6 +4,8 @@ defmodule Trenino.MCP.Tools.DetectionToolsTest do
   alias Trenino.Hardware
   alias Trenino.MCP.Tools.DetectionTools
 
+  import Trenino.PubSubHelpers, only: [wait_for_subscriber: 1]
+
   @input_values_topic "hardware:input_values"
   @test_port "test_port"
 
@@ -52,14 +54,14 @@ defmodule Trenino.MCP.Tools.DetectionToolsTest do
           })
         end)
 
-      # Give the detection session time to subscribe
-      Process.sleep(50)
+      # Wait deterministically for the detection session to subscribe
+      :ok = wait_for_subscriber("hardware:input_values:#{@test_port}")
 
       # Establish baseline then trigger change
       broadcast_input(button.pin, 0)
       broadcast_input(button.pin, 1)
 
-      assert {:ok, result} = Task.await(task, 3_000)
+      assert {:ok, result} = Task.await(task, 1_000)
       assert result.detected == true
       assert result.input.input_id == button.id
       assert result.input.input_type == :button
@@ -79,7 +81,7 @@ defmodule Trenino.MCP.Tools.DetectionToolsTest do
           })
         end)
 
-      Process.sleep(50)
+      :ok = wait_for_subscriber("hardware:input_values:#{@test_port}")
 
       # Analog input should be ignored when filtering for buttons
       broadcast_input(analog.pin, 0)
@@ -89,7 +91,7 @@ defmodule Trenino.MCP.Tools.DetectionToolsTest do
       broadcast_input(button.pin, 0)
       broadcast_input(button.pin, 1)
 
-      assert {:ok, result} = Task.await(task, 2_000)
+      assert {:ok, result} = Task.await(task, 1_000)
       assert result.detected == true
       assert result.input.input_type == :button
     end
@@ -153,12 +155,12 @@ defmodule Trenino.MCP.Tools.DetectionToolsTest do
           })
         end)
 
-      Process.sleep(50)
+      :ok = wait_for_subscriber("hardware:input_values:#{@test_port}")
 
       broadcast_input(analog.pin, 500)
       broadcast_input(analog.pin, 600)
 
-      assert {:ok, result} = Task.await(task, 3_000)
+      assert {:ok, result} = Task.await(task, 1_000)
       assert result.detected == true
       assert result.input.input_type == :analog
     end

--- a/test/trenino/mcp/tools/detection_tools_test.exs
+++ b/test/trenino/mcp/tools/detection_tools_test.exs
@@ -1,6 +1,5 @@
 defmodule Trenino.MCP.Tools.DetectionToolsTest do
   use Trenino.DataCase, async: false
-  use Mimic
 
   alias Trenino.Hardware
   alias Trenino.MCP.Tools.DetectionTools

--- a/test/trenino/mcp/tools/device_tools_test.exs
+++ b/test/trenino/mcp/tools/device_tools_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.MCP.Tools.DeviceToolsTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Hardware
   alias Trenino.MCP.Tools.DeviceTools

--- a/test/trenino/mcp/tools/element_tools_test.exs
+++ b/test/trenino/mcp/tools/element_tools_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.MCP.Tools.ElementToolsTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.MCP.Tools.ElementTools
   alias Trenino.Train, as: TrainContext

--- a/test/trenino/mcp/tools/output_binding_tools_test.exs
+++ b/test/trenino/mcp/tools/output_binding_tools_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.MCP.Tools.OutputBindingToolsTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Hardware
   alias Trenino.MCP.Tools.OutputBindingTools

--- a/test/trenino/mcp/tools/script_tools_test.exs
+++ b/test/trenino/mcp/tools/script_tools_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.MCP.Tools.ScriptToolsTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.MCP.Tools.ScriptTools
   alias Trenino.Train, as: TrainContext

--- a/test/trenino/mcp/tools/sequence_tools_test.exs
+++ b/test/trenino/mcp/tools/sequence_tools_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.MCP.Tools.SequenceToolsTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.MCP.Tools.SequenceTools
   alias Trenino.Train, as: TrainContext

--- a/test/trenino/mcp/tools/simulator_tools_test.exs
+++ b/test/trenino/mcp/tools/simulator_tools_test.exs
@@ -1,6 +1,5 @@
 defmodule Trenino.MCP.Tools.SimulatorToolsTest do
   use Trenino.DataCase, async: false
-  use Mimic
 
   alias Trenino.MCP.Tools.SimulatorTools
   alias Trenino.Simulator.Client

--- a/test/trenino/mcp/tools/simulator_tools_test.exs
+++ b/test/trenino/mcp/tools/simulator_tools_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.MCP.Tools.SimulatorToolsTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.MCP.Tools.SimulatorTools
   alias Trenino.Simulator.Client

--- a/test/trenino/mcp/tools/train_tools_test.exs
+++ b/test/trenino/mcp/tools/train_tools_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.MCP.Tools.TrainToolsTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.MCP.Tools.TrainTools
   alias Trenino.Train, as: TrainContext

--- a/test/trenino/serial/connection_port_timeout_test.exs
+++ b/test/trenino/serial/connection_port_timeout_test.exs
@@ -7,8 +7,7 @@ defmodule Trenino.Serial.Connection.PortTimeoutTest do
   Connection process.
   """
 
-  use ExUnit.Case, async: false
-  use Mimic
+  use Trenino.SerialSafetyCase, async: false
 
   alias Trenino.Serial.Connection
 

--- a/test/trenino/serial/connection_port_timeout_test.exs
+++ b/test/trenino/serial/connection_port_timeout_test.exs
@@ -117,7 +117,7 @@ defmodule Trenino.Serial.Connection.PortTimeoutTest do
           Connection.list_devices()
         end)
 
-      result = Task.yield(task, 6_000) || Task.shutdown(task)
+      result = Task.yield(task, 1_000) || Task.shutdown(task)
 
       assert {:ok, devices} = result
       assert devices == []
@@ -146,7 +146,7 @@ defmodule Trenino.Serial.Connection.PortTimeoutTest do
           Connection.connected_devices()
         end)
 
-      result = Task.yield(task, 6_000) || Task.shutdown(task)
+      result = Task.yield(task, 1_000) || Task.shutdown(task)
 
       assert {:ok, devices} = result
       assert devices == []

--- a/test/trenino/simulator/client_test.exs
+++ b/test/trenino/simulator/client_test.exs
@@ -1,6 +1,5 @@
 defmodule Trenino.Simulator.ClientTest do
-  use ExUnit.Case, async: true
-  use Mimic
+  use Trenino.SerialSafetyCase, async: true
 
   alias Trenino.Simulator.Client
 

--- a/test/trenino/simulator/connection_test.exs
+++ b/test/trenino/simulator/connection_test.exs
@@ -1,6 +1,5 @@
 defmodule Trenino.Simulator.ConnectionTest do
-  use ExUnit.Case, async: false
-  use Mimic
+  use Trenino.SerialSafetyCase, async: false
 
   alias Trenino.Settings
   alias Trenino.Simulator.Connection

--- a/test/trenino/simulator/control_detection_session_test.exs
+++ b/test/trenino/simulator/control_detection_session_test.exs
@@ -1,7 +1,5 @@
 defmodule Trenino.Simulator.ControlDetectionSessionTest do
-  use ExUnit.Case, async: false
-
-  import Mimic
+  use Trenino.SerialSafetyCase, async: false
 
   alias Trenino.Simulator.Client
   alias Trenino.Simulator.ControlDetectionSession

--- a/test/trenino/simulator/lever_analyzer_test.exs
+++ b/test/trenino/simulator/lever_analyzer_test.exs
@@ -5,8 +5,7 @@ defmodule Trenino.Simulator.LeverAnalyzerTest do
   These tests verify the full analyze/3 flow with mocked HTTP responses.
   For fast unit tests of the analysis logic, see LeverAnalyzer.AnalysisTest.
   """
-  use ExUnit.Case, async: true
-  use Mimic
+  use Trenino.SerialSafetyCase, async: true
 
   alias Trenino.Simulator.Client
   alias Trenino.Simulator.LeverAnalyzer

--- a/test/trenino/train/button_input_binding_test.exs
+++ b/test/trenino/train/button_input_binding_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Train.ButtonInputBindingTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Hardware
   alias Trenino.Train, as: TrainContext

--- a/test/trenino/train/calibration/lever_session_test.exs
+++ b/test/trenino/train/calibration/lever_session_test.exs
@@ -1,6 +1,5 @@
 defmodule Trenino.Train.Calibration.LeverSessionTest do
   use Trenino.DataCase, async: false
-  use Mimic
 
   alias Trenino.Simulator.Client
   alias Trenino.Train

--- a/test/trenino/train/calibration/notch_mapping_session_test.exs
+++ b/test/trenino/train/calibration/notch_mapping_session_test.exs
@@ -1,5 +1,8 @@
 defmodule Trenino.Train.Calibration.NotchMappingSessionTest do
-  use Trenino.DataCase, async: true
+  # async: false because the test uses Sandbox.allow/3 to grant DB access
+  # to spawned NotchMappingSession processes — that API requires the shared
+  # Sandbox pool, not the dynamic isolated Repo used for async tests.
+  use Trenino.DataCase, async: false
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Trenino.Hardware

--- a/test/trenino/train/calibration/notch_mapping_session_test.exs
+++ b/test/trenino/train/calibration/notch_mapping_session_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Train.Calibration.NotchMappingSessionTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Trenino.Hardware

--- a/test/trenino/train/detection_test.exs
+++ b/test/trenino/train/detection_test.exs
@@ -1,6 +1,5 @@
 defmodule Trenino.Train.DetectionTest do
   use Trenino.DataCase, async: false
-  use Mimic
 
   alias Trenino.Simulator.Client
   alias Trenino.Simulator.ConnectionState

--- a/test/trenino/train/lever_controller_bldc_test.exs
+++ b/test/trenino/train/lever_controller_bldc_test.exs
@@ -8,7 +8,6 @@ defmodule Trenino.Train.LeverControllerBLDCTest do
   - Non-BLDC levers are skipped
   """
   use Trenino.DataCase, async: false
-  use Mimic
 
   import ExUnit.CaptureLog
 

--- a/test/trenino/train/lever_controller_bldc_test.exs
+++ b/test/trenino/train/lever_controller_bldc_test.exs
@@ -194,8 +194,9 @@ defmodule Trenino.Train.LeverControllerBLDCTest do
       # Activate train with both BLDC and non-BLDC levers
       send(LeverController, {:train_changed, train})
 
-      # Wait for profile loading to complete
-      Process.sleep(200)
+      # Wait for the one expected BLDC profile, then confirm no more arrive
+      assert_receive {:bldc_profile_loaded, _}, 500
+      refute_receive {:bldc_profile_loaded, _}, 50
 
       # Should only receive one profile load (for the BLDC lever, not the continuous one)
       assert :counters.get(profile_count, 1) == 1
@@ -209,7 +210,8 @@ defmodule Trenino.Train.LeverControllerBLDCTest do
       log =
         capture_log(fn ->
           send(LeverController, {:train_changed, train})
-          Process.sleep(100)
+          # Sync with the GenServer to ensure handle_info has run before capture_log exits
+          LeverController.get_state()
         end)
 
       assert log =~ "No device connected, skipping BLDC profile loading"

--- a/test/trenino/train/lever_mapper_test.exs
+++ b/test/trenino/train/lever_mapper_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Train.LeverMapperTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Train.{LeverConfig, LeverMapper, Notch}
 

--- a/test/trenino/train/notch_test.exs
+++ b/test/trenino/train/notch_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Train.NotchTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Train.Notch
 

--- a/test/trenino/train/output_binding_context_test.exs
+++ b/test/trenino/train/output_binding_context_test.exs
@@ -2,7 +2,7 @@ defmodule Trenino.Train.OutputBindingContextTest do
   @moduledoc """
   Tests for output binding context functions in Trenino.Train module.
   """
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Hardware
   alias Trenino.Train, as: TrainContext

--- a/test/trenino/train/output_binding_test.exs
+++ b/test/trenino/train/output_binding_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Train.OutputBindingTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Hardware
   alias Trenino.Train, as: TrainContext

--- a/test/trenino/train/output_controller_test.exs
+++ b/test/trenino/train/output_controller_test.exs
@@ -8,7 +8,7 @@ defmodule Trenino.Train.OutputControllerTest do
   - Train activation/deactivation handling
   - Subscription management
   """
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Hardware
   alias Trenino.Train, as: TrainContext

--- a/test/trenino/train/script_context_test.exs
+++ b/test/trenino/train/script_context_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Train.ScriptContextTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Train, as: TrainContext
   alias Trenino.Train.Script

--- a/test/trenino/train/script_runner_test.exs
+++ b/test/trenino/train/script_runner_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Train.ScriptRunnerTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Train, as: TrainContext
 

--- a/test/trenino/train/script_test.exs
+++ b/test/trenino/train/script_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.Train.ScriptTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Train, as: TrainContext
   alias Trenino.Train.Script

--- a/test/trenino/train_test.exs
+++ b/test/trenino/train_test.exs
@@ -1,5 +1,5 @@
 defmodule Trenino.TrainTest do
-  use Trenino.DataCase, async: false
+  use Trenino.DataCase, async: true
 
   alias Trenino.Hardware
   alias Trenino.Train, as: TrainContext

--- a/test/trenino_web/live/components/configuration_wizard_component_test.exs
+++ b/test/trenino_web/live/components/configuration_wizard_component_test.exs
@@ -1,6 +1,5 @@
 defmodule TreninoWeb.ConfigurationWizardComponentTest do
   use TreninoWeb.ConnCase, async: false
-  use Mimic
 
   import Phoenix.LiveViewTest
 

--- a/test/trenino_web/live/components/endpoint_selector_component_test.exs
+++ b/test/trenino_web/live/components/endpoint_selector_component_test.exs
@@ -1,6 +1,5 @@
 defmodule TreninoWeb.EndpointSelectorComponentTest do
   use TreninoWeb.ConnCase, async: false
-  use Mimic
 
   import Phoenix.LiveViewTest
 

--- a/test/trenino_web/live/components/lever_setup_wizard_test.exs
+++ b/test/trenino_web/live/components/lever_setup_wizard_test.exs
@@ -1,6 +1,5 @@
 defmodule TreninoWeb.LeverSetupWizardTest do
   use TreninoWeb.ConnCase, async: false
-  use Mimic
 
   import Phoenix.LiveViewTest
 

--- a/test/trenino_web/live/components/sequence_manager_component_test.exs
+++ b/test/trenino_web/live/components/sequence_manager_component_test.exs
@@ -1,6 +1,5 @@
 defmodule TreninoWeb.SequenceManagerComponentTest do
   use TreninoWeb.ConnCase, async: false
-  use Mimic
 
   import Phoenix.LiveViewTest
 

--- a/test/trenino_web/live/configuration_list_live_test.exs
+++ b/test/trenino_web/live/configuration_list_live_test.exs
@@ -6,11 +6,24 @@ defmodule TreninoWeb.ConfigurationListLiveTest do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Trenino.Hardware
+  alias Trenino.Serial.Connection
   alias Trenino.Simulator.ConnectionState
 
   # Allow the Connection GenServer to access the database sandbox
   setup do
     Sandbox.mode(Trenino.Repo, {:shared, self()})
+    :ok
+  end
+
+  # Stub serial Connection calls that would otherwise hit the real GenServer.
+  # Connection.scan/0 is a GenServer.cast and Connection.list_devices/0 is a
+  # GenServer.call; without stubs both go to the running process and can add
+  # 200ms+ per test while the GenServer processes the request and attempts
+  # (forbidden) UART enumeration.
+  setup do
+    stub(Connection, :scan, fn -> :ok end)
+    stub(Connection, :connected_devices, fn -> [] end)
+    stub(Connection, :list_devices, fn -> [] end)
     :ok
   end
 

--- a/test/trenino_web/live/nav_hook_test.exs
+++ b/test/trenino_web/live/nav_hook_test.exs
@@ -7,7 +7,6 @@ defmodule TreninoWeb.NavHookTest do
   """
 
   use TreninoWeb.ConnCase, async: false
-  use Mimic
 
   import Phoenix.LiveViewTest
 


### PR DESCRIPTION
## Summary

- Extract `AvrdudeRunner` module as a Mimic-stubbable seam, enabling regression tests without spawning real avrdude processes
- Replace fixed 1500 ms bootloader sleep with a 5-second polling loop (300 ms intervals) so Windows COM port redetection succeeds on slower USB chipsets
- Report upload failures to Sentry with full avrdude output as structured context (`upload_id`, `port`, `environment`, `error_reason`, `avrdude_output`)
- Reject manifest devices whose upload protocol is not in the avrdude allowlist (`arduino avr109 wiring avrisp usbasp`), removing ESP32/Due from the device dropdown

## Test Plan

- [ ] 1346 tests, 0 failures (`mix test`)
- [ ] New regression tests in `test/trenino/firmware/upload_flow_test.exs` cover: successful upload, non-retrying errors (wrong board, permission denied, verification error), baud-rate retry for old-bootloader Nano, and Windows 1200bps touch port polling
- [ ] `DeviceRegistry` tests confirm `due` (sam-ba) and `esp32dev` (esptool) are rejected at load time
- [ ] Verify on a real Micro / Nano old-bootloader that upload succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)